### PR TITLE
ci: only fail version bump if semanatic release exits non zero

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -15,6 +15,8 @@ jobs:
       # added or changed files to the repository.
       contents: write
 
+    # Only run if the commit message does not start with 'build:'
+    if: startsWith(github.event.head_commit.message, 'build:') != true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,21 +68,31 @@ jobs:
         id: get-version
         run: |
           # Run semantic-release with full output for debugging
+          set +e  # Don't exit on error
           SEMANTIC_OUTPUT=$(npx semantic-release --dry-run --debug 2>&1)
+          SEMANTIC_EXIT_CODE=$?
+          set -e  # Re-enable exit on error
+          
           echo "semantic-release output:"
           echo "$SEMANTIC_OUTPUT"
+          
+          if [ $SEMANTIC_EXIT_CODE -ne 0 ]; then
+            echo "semantic-release failed with exit code $SEMANTIC_EXIT_CODE"
+            exit 1
+          fi
           
           # Try to extract the version
           VERSION_SPACES=$(echo "$SEMANTIC_OUTPUT" | grep -oP 'Published release \K.*? ' || echo "")
           VERSION="${VERSION_SPACES// /}"
           
           if [ -z "$VERSION" ]; then
-            echo "Failed to extract version. semantic-release may have failed."
-            exit 1
+            echo "No new version to be published."
+            VERSION=""
           else
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "Extracted version: $VERSION"
           fi
+          
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Log If no version to bump t
         if: steps.get-version.outputs.version == ''


### PR DESCRIPTION
also skip version bump check on commits that start with build:

aka the version bump ones
