### PR TITLE
fix: auto dismiss when manual rescan is enabled

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,6 +44,10 @@ android {
                 abortOnError false
             }
         }
+
+      customDebugType {
+        debuggable true
+      }
     }
 
     sourceSets {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -46,6 +46,8 @@ android {
         }
 
       customDebugType {
+        initWith debug
+        matchingFallbacks = ['debug']
         debuggable true
       }
     }

--- a/android/app/src/main/java/com/github/quarck/calnotify/app/ApplicationController.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/app/ApplicationController.kt
@@ -593,6 +593,8 @@ object ApplicationController : EventMovedHandler {
     ): Boolean {
         var ret = false
 
+        DevLog.info(LOG_TAG, "Event ${eventId} - checking if should auto remove, oldStartTime $oldStartTime,  newStartTime $newStartTime,  newAlertTime $newAlertTime, ")
+
         if (newStartTime - oldStartTime > Consts.EVENT_MOVE_THRESHOLD) {
             if (newAlertTime > System.currentTimeMillis() + Consts.ALARM_THRESHOLD) {
 

--- a/android/app/src/main/java/com/github/quarck/calnotify/app/CalendarReloadManager.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/app/CalendarReloadManager.kt
@@ -72,6 +72,8 @@ object CalendarReloadManager : CalendarReloadManagerInterface {
             try {
                 val reloadResult = reloadCalendarEventAlert(context, calendar, event, currentTime, movedHandler)
 
+                DevLog.debug(LOG_TAG, "reloadCalendarInternal: Event ${event.eventId} - reloadResult.code ${reloadResult.code} ")
+
                 when (reloadResult.code) {
                 // nothing required
                     ReloadCalendarResultCode.NoChange ->
@@ -154,8 +156,7 @@ object CalendarReloadManager : CalendarReloadManagerInterface {
             calendar: CalendarProviderInterface,
             movedHandler: EventMovedHandler?
     ): Boolean {
-        // don't rescan manually created requests - we won't find most of them
-        val events = db.events.filter { event -> event.origin != EventOrigin.FullManual && event.isNotSpecial }
+        val events = db.events.filter { event -> event.isNotSpecial }
         return reloadCalendarInternal(context, db, events, calendar, movedHandler)
     }
 


### PR DESCRIPTION
now if you reschedule a bunch of events outside of the app it will auto
dismiss them "onAppResume" if they are far enough in the future even with manual
rescan enabled

its unclear why this was disabled in this state in the first place
