### PR TITLE
ci: fix intermittent build failures and some other things

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+# Dont change any non test code without getting confirmation first
+
+Dont change any non test code without getting confirmation first. this is a very old application I'm working on making a thorough test suite for before making any changes
+
+
+# Work to make tests as faithful to the real code as possible
+
+its ok to mock out core android apis that the instrumentation testsuite doesn't work well with i.e. making push notifications but try to use the real original code for anything that exists in this codebase
+
+
+# Don't try to boil the ocean. Dont try to make big sweeping changes when more focused ones will do
+
+Always think of the minimum viable solution to a problem or change to make. make sure that works and then build on top of it. break things down into small testable pieces firs

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,9 @@ env:
   # Explicitly set CI flag to true for our Gradle task
   CI: true
 
+  # Build datetime for all jobs to use
+  build_datetime: ${{ format('{0:yyyy-MM-dd HH_mm_ss}', github.event.head_commit.timestamp) }}
+
   # Android Emulator Configuration
   ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 5
   ANDROID_API_LEVEL: 34
@@ -55,7 +58,6 @@ jobs:
       BUILD_ARCH: ${{ matrix.arch }}
     timeout-minutes: 30
     outputs:
-      build_datetime: ${{ steps.set_date.outputs.build_datetime }}
       repository_name: ${{ steps.set_repo.outputs.repository_name }}
 
     steps:
@@ -68,12 +70,7 @@ jobs:
       with:
         create-symlink: true
 
-    # Set current date and repository name
-    - name: Set current date as env variable
-      id: set_date
-      run: |
-        echo "build_datetime=$(date +'%Y-%m-%d %H_%M_%S')" >> $GITHUB_OUTPUT
-
+    # Set repository name as env variable
     - name: Set repository name as env variable
       id: set_repo
       run: |
@@ -190,7 +187,6 @@ jobs:
       # Import build variables from build job
       - name: Set build variables
         run: |
-          echo "build_datetime=${{ needs.build.outputs.build_datetime }}" >> $GITHUB_ENV
           echo "repository_name=${{ needs.build.outputs.repository_name }}" >> $GITHUB_ENV
 
       # Download build artifacts for current architecture
@@ -308,19 +304,19 @@ jobs:
       - name: Upload SIGNED APK Debug
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ needs.build.outputs.build_datetime }}-${{ env.app_name }}-APK-debug-${{ matrix.arch }}"
+          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-APK-debug-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*-debug.apk
 
       - name: Upload SIGNED APK RELEASE
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ needs.build.outputs.build_datetime }}-${{ env.app_name }}-APK-release-${{ matrix.arch }}"
+          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-APK-release-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*-release.apk
 
       - name: Upload SIGNED AAB (App Bundle) Release
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ needs.build.outputs.build_datetime }}-${{ env.app_name }}-AAB-release-${{ matrix.arch }}"
+          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-AAB-release-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*.aab
 
   comment-pr:
@@ -439,7 +435,7 @@ jobs:
         retention-days: 90
 
 
-  # integration-test:
+  # connected-android-integration-test:
   #   name: Test Android App
   #   needs: [build]
   #   runs-on: ubuntu-latest
@@ -470,6 +466,7 @@ jobs:
   #       android_target: ${{ env.ANDROID_TARGET }}
   #       android_profile: ${{ env.ANDROID_PROFILE }}
   #       run_emulator_setup: "true"
+  #       optional_cache_key: "connected-android-integration-test"
 
   #   - name: Make scripts executable
   #     run: |
@@ -490,7 +487,7 @@ jobs:
   #       target: ${{ env.ANDROID_TARGET }}
   #       arch: ${{ matrix.arch }}
   #       profile: ${{ env.ANDROID_PROFILE }}
-  #       avd-name: 'integration-test'
+  #       avd-name: 'connected-android-integration-test'
   #       force-avd-creation: false
   #       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -no-snapshot -memory 2048
   #       disable-animations: true
@@ -646,7 +643,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: android-test-coverage-report-${{ needs.build.outputs.build_datetime }}
+        name: android-test-coverage-report-${{ env.build_datetime }}
         path: |
           android/app/build/reports/
           android/app/build/reports/jacoco/jacocoAndroidTestReport/
@@ -691,7 +688,7 @@ jobs:
       - name: Download unit test coverage
         uses: actions/download-artifact@v4
         with:
-          name: unit-test-results-${{ needs.build.outputs.build_datetime }}
+          name: unit-test-results-${{ env.build_datetime }}
           # path relative to build directory. because highest common directory is build
           path: coverage-data/unit-tests/android/app/build/
         continue-on-error: true
@@ -699,7 +696,7 @@ jobs:
       - name: Download integration test coverage
         uses: actions/download-artifact@v4
         with:
-          name: android-test-coverage-report-${{ needs.build.outputs.build_datetime }}
+          name: android-test-coverage-report-${{ env.build_datetime }}
           # path relative to build directory. because highest common directory is build
           path: coverage-data/integration-tests/android/app/build/
         continue-on-error: true
@@ -722,7 +719,7 @@ jobs:
       - name: Upload HTML Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-report-html-${{ needs.build.outputs.build_datetime }}
+          name: code-coverage-report-html-${{ env.build_datetime }}
           path: |
             coverage-data/unit-tests/android/app/build/reports/jacoco/**/html
             coverage-data/integration-tests/android/app/build/reports/jacoco/**/html

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -704,16 +704,18 @@ jobs:
       # Process and generate coverage report from Jacoco XML files
       - name: Generate JaCoCo Coverage Report
         id: jacoco
-        uses: madrapps/jacoco-report@v1.6.1
+        uses: madrapps/jacoco-report@v1.7.0
         with:
           paths: |
             ${{ github.workspace }}/coverage-data/unit-tests/android/app/build/reports/coverage/**/*.xml
             ${{ github.workspace }}/coverage-data/integration-tests/android/app/build/reports/jacoco/**/*.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 30
-          min-coverage-changed-files: 60
+          min-coverage-overall: 60
+          min-coverage-changed-files: 80
           title: 'Code Coverage Report'
           update-comment: true
+          pass-emoji: '✅'
+          fail-emoji: '❌'
 
       # Upload detailed HTML coverage report
       - name: Upload HTML Coverage Report
@@ -734,10 +736,10 @@ jobs:
           script: |
             const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const coverageSummary = `
-            | Type | Coverage |
-            | ---- | -------- |
-            | Line | ${{ steps.jacoco.outputs.coverage-overall }} |
-            | Branch | ${{ steps.jacoco.outputs.branches-overall }} |
+            | Coverage Type | Coverage |
+            | ------------ | -------- |
+            | Overall | ${{ steps.jacoco.outputs.coverage-overall }}% |
+            | Changed Files | ${{ steps.jacoco.outputs.coverage-changed-files }}% |
 
             [View detailed coverage report](${workflowUrl}#artifacts)
             `;

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,9 +13,6 @@ env:
   # Explicitly set CI flag to true for our Gradle task
   CI: true
 
-  # Build datetime for all jobs to use
-  build_datetime: ${{ format('{0:yyyy-MM-dd HH_mm_ss}', github.event.head_commit.timestamp) }}
-
   # Android Emulator Configuration
   ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 5
   ANDROID_API_LEVEL: 34
@@ -45,8 +42,20 @@ on:
   workflow_dispatch:
 
 jobs:
+  set_build_datetime:
+    name: Set Build Datetime
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Build Datetime
+        id: set_date
+        run: |
+          echo "build_datetime=$(date +'%Y-%m-%d %H_%M_%S')" >> $GITHUB_OUTPUT
+    outputs:
+      build_datetime: ${{ steps.set_date.outputs.build_datetime }}
+
   build:
     name: Build Android App
+    needs: set_build_datetime
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -170,7 +179,7 @@ jobs:
 
   sign:
     name: Sign Android APKs and Bundles (${{ matrix.arch }})
-    needs: build
+    needs: [set_build_datetime, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -304,19 +313,19 @@ jobs:
       - name: Upload SIGNED APK Debug
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-APK-debug-${{ matrix.arch }}"
+          name: "signed-${{ needs.set_build_datetime.outputs.build_datetime }}-${{ env.app_name }}-APK-debug-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*-debug.apk
 
       - name: Upload SIGNED APK RELEASE
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-APK-release-${{ matrix.arch }}"
+          name: "signed-${{ needs.set_build_datetime.outputs.build_datetime }}-${{ env.app_name }}-APK-release-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*-release.apk
 
       - name: Upload SIGNED AAB (App Bundle) Release
         uses: actions/upload-artifact@v4
         with:
-          name: "signed-${{ env.build_datetime }}-${{ env.app_name }}-AAB-release-${{ matrix.arch }}"
+          name: "signed-${{ needs.set_build_datetime.outputs.build_datetime }}-${{ env.app_name }}-AAB-release-${{ matrix.arch }}"
           path: renamed_apks/${{env.app_file_name_prefix}}-*.aab
 
   comment-pr:
@@ -347,6 +356,7 @@ jobs:
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest
+    needs: set_build_datetime
     timeout-minutes: 15
     strategy:
       matrix:
@@ -427,7 +437,7 @@ jobs:
       if: always() # Always upload results even if tests fail
       uses: actions/upload-artifact@v4
       with:
-        name: unit-test-results-${{ env.build_datetime }}
+        name: unit-test-results-${{ needs.set_build_datetime.outputs.build_datetime }}
         path: |
           android/app/build/reports/
           android/app/build/test-results/
@@ -552,7 +562,7 @@ jobs:
   # 2. we need to get the xml file that does the test results for the dorny thing
   integration-test:
     name: Test Android App
-    needs: [build]
+    needs: [set_build_datetime, build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -643,7 +653,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: android-test-coverage-report-${{ env.build_datetime }}
+        name: android-test-coverage-report-${{ needs.set_build_datetime.outputs.build_datetime }}
         path: |
           android/app/build/reports/
           android/app/build/reports/jacoco/jacocoAndroidTestReport/
@@ -676,7 +686,7 @@ jobs:
 
   coverage-report:
     name: Process Code Coverage
-    needs: [unit-tests, build, integration-test]
+    needs: [set_build_datetime,unit-tests, build, integration-test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -688,7 +698,7 @@ jobs:
       - name: Download unit test coverage
         uses: actions/download-artifact@v4
         with:
-          name: unit-test-results-${{ env.build_datetime }}
+          name: unit-test-results-${{ needs.set_build_datetime.outputs.build_datetime }}
           # path relative to build directory. because highest common directory is build
           path: coverage-data/unit-tests/android/app/build/
         continue-on-error: true
@@ -696,7 +706,7 @@ jobs:
       - name: Download integration test coverage
         uses: actions/download-artifact@v4
         with:
-          name: android-test-coverage-report-${{ env.build_datetime }}
+          name: android-test-coverage-report-${{ needs.set_build_datetime.outputs.build_datetime }}
           # path relative to build directory. because highest common directory is build
           path: coverage-data/integration-tests/android/app/build/
         continue-on-error: true
@@ -704,24 +714,22 @@ jobs:
       # Process and generate coverage report from Jacoco XML files
       - name: Generate JaCoCo Coverage Report
         id: jacoco
-        uses: madrapps/jacoco-report@v1.7.0
+        uses: madrapps/jacoco-report@v1.6.1
         with:
           paths: |
             ${{ github.workspace }}/coverage-data/unit-tests/android/app/build/reports/coverage/**/*.xml
             ${{ github.workspace }}/coverage-data/integration-tests/android/app/build/reports/jacoco/**/*.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 60
-          min-coverage-changed-files: 80
+          min-coverage-overall: 30
+          min-coverage-changed-files: 60
           title: 'Code Coverage Report'
           update-comment: true
-          pass-emoji: '✅'
-          fail-emoji: '❌'
 
       # Upload detailed HTML coverage report
       - name: Upload HTML Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: code-coverage-report-html-${{ env.build_datetime }}
+          name: code-coverage-report-html-${{ needs.set_build_datetime.outputs.build_datetime }}
           path: |
             coverage-data/unit-tests/android/app/build/reports/jacoco/**/html
             coverage-data/integration-tests/android/app/build/reports/jacoco/**/html
@@ -737,9 +745,9 @@ jobs:
             const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const coverageSummary = `
             | Coverage Type | Coverage |
-            | ------------ | -------- |
-            | Overall | ${{ steps.jacoco.outputs.coverage-overall }}% |
-            | Changed Files | ${{ steps.jacoco.outputs.coverage-changed-files }}% |
+            | ---- | -------- |
+            | Overall | ${{ steps.jacoco.outputs.coverage-overall }} |
+            | Changed Files | ${{ steps.jacoco.outputs.coverage-changed-files }} |
 
             [View detailed coverage report](${workflowUrl}#artifacts)
             `;

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -427,7 +427,7 @@ jobs:
       if: always() # Always upload results even if tests fail
       uses: actions/upload-artifact@v4
       with:
-        name: unit-test-results
+        name: unit-test-results-${{ env.build_datetime }}
         path: |
           android/app/build/reports/
           android/app/build/test-results/

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -423,6 +423,7 @@ jobs:
         name: 'Unit Tests'
         path: 'android/${{ env.main_project_module }}/build/test-results/test*DebugUnitTest/**/*.xml'
         reporter: java-junit
+        use-actions-summary: 'true'
         fail-on-error: true
 
     # Upload test results

--- a/.github/workflows/test-summary.yml
+++ b/.github/workflows/test-summary.yml
@@ -23,12 +23,27 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
           
+      - name: Find latest test artifacts
+        id: find_artifacts
+        run: |
+          # Find the most recent unit test results directory
+          UNIT_TEST_DIR=$(find artifacts -type d -name "unit-test-results-*" | sort -r | head -n1)
+          echo "unit_test_dir=$UNIT_TEST_DIR" >> $GITHUB_OUTPUT
+          
+          # Find the most recent integration test results directory
+          INTEGRATION_TEST_DIR=$(find artifacts -type d -name "android-test-coverage-report-*" | sort -r | head -n1)
+          echo "integration_test_dir=$INTEGRATION_TEST_DIR" >> $GITHUB_OUTPUT
+          
+          # Find the most recent coverage report directory
+          COVERAGE_DIR=$(find artifacts -type d -name "code-coverage-report-html-*" | sort -r | head -n1)
+          echo "coverage_dir=$COVERAGE_DIR" >> $GITHUB_OUTPUT
+          
       - name: Publish Unit Test Summary
         uses: dorny/test-reporter@v2
         if: always()
         with:
           name: 'Unit Tests Summary'
-          path: 'artifacts/unit-test-results/android/app/build/test-results/test*DebugUnitTest/**/*.xml'
+          path: '${{ steps.find_artifacts.outputs.unit_test_dir }}/android/app/build/test-results/test*DebugUnitTest/**/*.xml'
           reporter: java-junit
           fail-on-error: false
           use-actions-summary: true
@@ -39,7 +54,7 @@ jobs:
         if: always()
         with:
           name: 'Integration Tests Summary'
-          path: 'artifacts/android-test-coverage-report/android/app/build/outputs/**/connected/**/TEST-*.xml'
+          path: '${{ steps.find_artifacts.outputs.integration_test_dir }}/android/app/build/outputs/**/connected/**/TEST-*.xml'
           reporter: java-junit
           fail-on-error: false
           use-actions-summary: true
@@ -51,8 +66,8 @@ jobs:
         with:
           name: 'Combined Test Report'
           path: |
-            artifacts/unit-test-results/android/app/build/test-results/test*DebugUnitTest/**/*.xml
-            artifacts/android-test-coverage-report/android/app/build/outputs/**/connected/**/TEST-*.xml
+            ${{ steps.find_artifacts.outputs.unit_test_dir }}/android/app/build/test-results/test*DebugUnitTest/**/*.xml
+            ${{ steps.find_artifacts.outputs.integration_test_dir }}/android/app/build/outputs/**/connected/**/TEST-*.xml
           reporter: java-junit
           fail-on-error: false
           only-summary: true
@@ -66,17 +81,17 @@ jobs:
           echo "## 📊 Code Coverage" >> $GITHUB_STEP_SUMMARY
           
           # First, check if there's a coverage-report-html artifact with the placeholder file
-          if [ -d "artifacts/coverage-report-html" ] && [ -f "artifacts/coverage-report-html/index.html" ]; then
+          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/index.html" ]; then
             echo "JaCoCo HTML report is available in the artifacts." >> $GITHUB_STEP_SUMMARY
           fi
           
           # Check if coverage badge files exist
-          if [ -d "artifacts/coverage-badges" ]; then
-            if [ -f "artifacts/coverage-badges/jacoco.svg" ] && [ -f "artifacts/coverage-badges/jacoco.json" ]; then
-              LINE_COVERAGE=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.coverage')
-              COVERED_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.covered')
-              MISSED_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.missed')
-              TOTAL_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.branches.total')
+          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges" ]; then
+            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" ]; then
+              LINE_COVERAGE=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.coverage')
+              COVERED_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.covered')
+              MISSED_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.missed')
+              TOTAL_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.branches.total')
               
               echo "### Line Coverage: ${LINE_COVERAGE}%" >> $GITHUB_STEP_SUMMARY
               echo "- Covered Lines: ${COVERED_LINES}" >> $GITHUB_STEP_SUMMARY
@@ -87,11 +102,11 @@ jobs:
               echo "No line coverage data available." >> $GITHUB_STEP_SUMMARY
             fi
             
-            if [ -f "artifacts/coverage-badges/branches.json" ]; then
-              BRANCH_COVERAGE=$(cat artifacts/coverage-badges/branches.json | jq -r '.coverage')
-              COVERED_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.covered')
-              MISSED_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.missed')
-              TOTAL_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.total')
+            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" ]; then
+              BRANCH_COVERAGE=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.coverage')
+              COVERED_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.covered')
+              MISSED_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.missed')
+              TOTAL_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.total')
               
               echo "### Branch Coverage: ${BRANCH_COVERAGE}%" >> $GITHUB_STEP_SUMMARY
               echo "- Covered Branches: ${COVERED_BRANCHES}" >> $GITHUB_STEP_SUMMARY
@@ -105,9 +120,9 @@ jobs:
             XML_COUNT=0
             HTML_COUNT=0
             
-            if [ -d "artifacts/android-test-coverage-report" ]; then
-              XML_COUNT=$(find artifacts/android-test-coverage-report -name "*.xml" | grep -i jacoco | wc -l)
-              HTML_COUNT=$(find artifacts/android-test-coverage-report -name "*.html" | grep -i jacoco | wc -l)
+            if [ -d "${{ steps.find_artifacts.outputs.integration_test_dir }}" ]; then
+              XML_COUNT=$(find "${{ steps.find_artifacts.outputs.integration_test_dir }}" -name "*.xml" | grep -i jacoco | wc -l)
+              HTML_COUNT=$(find "${{ steps.find_artifacts.outputs.integration_test_dir }}" -name "*.html" | grep -i jacoco | wc -l)
             fi
             
             echo "### Coverage Data" >> $GITHUB_STEP_SUMMARY
@@ -126,11 +141,11 @@ jobs:
         run: |
           echo "### Coverage Visualization" >> $GITHUB_STEP_SUMMARY
           
-          if [ -d "artifacts/coverage-badges" ] && [ -f "artifacts/coverage-badges/jacoco.svg" ] && [ -f "artifacts/coverage-badges/jacoco.json" ]; then
-            echo "![Coverage](https://img.shields.io/badge/Coverage-$(cat artifacts/coverage-badges/jacoco.json | jq -r '.coverage')%25-$(cat artifacts/coverage-badges/jacoco.json | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
+          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" ]; then
+            echo "![Coverage](https://img.shields.io/badge/Coverage-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.coverage')%25-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
             
-            if [ -f "artifacts/coverage-badges/branches.svg" ] && [ -f "artifacts/coverage-badges/branches.json" ]; then
-              echo "![Branch Coverage](https://img.shields.io/badge/Branch_Coverage-$(cat artifacts/coverage-badges/branches.json | jq -r '.coverage')%25-$(cat artifacts/coverage-badges/branches.json | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
+            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" ]; then
+              echo "![Branch Coverage](https://img.shields.io/badge/Branch_Coverage-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.coverage')%25-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
             fi
           else
             echo "No coverage badges available. Using placeholder badges instead." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-summary.yml
+++ b/.github/workflows/test-summary.yml
@@ -23,27 +23,12 @@ jobs:
           run_id: ${{ github.event.workflow_run.id }}
           path: artifacts
           
-      - name: Find latest test artifacts
-        id: find_artifacts
-        run: |
-          # Find the most recent unit test results directory
-          UNIT_TEST_DIR=$(find artifacts -type d -name "unit-test-results-*" | sort -r | head -n1)
-          echo "unit_test_dir=$UNIT_TEST_DIR" >> $GITHUB_OUTPUT
-          
-          # Find the most recent integration test results directory
-          INTEGRATION_TEST_DIR=$(find artifacts -type d -name "android-test-coverage-report-*" | sort -r | head -n1)
-          echo "integration_test_dir=$INTEGRATION_TEST_DIR" >> $GITHUB_OUTPUT
-          
-          # Find the most recent coverage report directory
-          COVERAGE_DIR=$(find artifacts -type d -name "code-coverage-report-html-*" | sort -r | head -n1)
-          echo "coverage_dir=$COVERAGE_DIR" >> $GITHUB_OUTPUT
-          
       - name: Publish Unit Test Summary
         uses: dorny/test-reporter@v2
         if: always()
         with:
           name: 'Unit Tests Summary'
-          path: '${{ steps.find_artifacts.outputs.unit_test_dir }}/android/app/build/test-results/test*DebugUnitTest/**/*.xml'
+          path: 'artifacts/unit-test-results/android/app/build/test-results/test*DebugUnitTest/**/*.xml'
           reporter: java-junit
           fail-on-error: false
           use-actions-summary: true
@@ -54,7 +39,7 @@ jobs:
         if: always()
         with:
           name: 'Integration Tests Summary'
-          path: '${{ steps.find_artifacts.outputs.integration_test_dir }}/android/app/build/outputs/**/connected/**/TEST-*.xml'
+          path: 'artifacts/android-test-coverage-report/android/app/build/outputs/**/connected/**/TEST-*.xml'
           reporter: java-junit
           fail-on-error: false
           use-actions-summary: true
@@ -66,8 +51,8 @@ jobs:
         with:
           name: 'Combined Test Report'
           path: |
-            ${{ steps.find_artifacts.outputs.unit_test_dir }}/android/app/build/test-results/test*DebugUnitTest/**/*.xml
-            ${{ steps.find_artifacts.outputs.integration_test_dir }}/android/app/build/outputs/**/connected/**/TEST-*.xml
+            artifacts/unit-test-results/android/app/build/test-results/test*DebugUnitTest/**/*.xml
+            artifacts/android-test-coverage-report/android/app/build/outputs/**/connected/**/TEST-*.xml
           reporter: java-junit
           fail-on-error: false
           only-summary: true
@@ -81,17 +66,17 @@ jobs:
           echo "## 📊 Code Coverage" >> $GITHUB_STEP_SUMMARY
           
           # First, check if there's a coverage-report-html artifact with the placeholder file
-          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/index.html" ]; then
+          if [ -d "artifacts/coverage-report-html" ] && [ -f "artifacts/coverage-report-html/index.html" ]; then
             echo "JaCoCo HTML report is available in the artifacts." >> $GITHUB_STEP_SUMMARY
           fi
           
           # Check if coverage badge files exist
-          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges" ]; then
-            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" ]; then
-              LINE_COVERAGE=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.coverage')
-              COVERED_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.covered')
-              MISSED_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.missed')
-              TOTAL_LINES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.branches.total')
+          if [ -d "artifacts/coverage-badges" ]; then
+            if [ -f "artifacts/coverage-badges/jacoco.svg" ] && [ -f "artifacts/coverage-badges/jacoco.json" ]; then
+              LINE_COVERAGE=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.coverage')
+              COVERED_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.covered')
+              MISSED_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.missed')
+              TOTAL_LINES=$(cat artifacts/coverage-badges/jacoco.json | jq -r '.branches.total')
               
               echo "### Line Coverage: ${LINE_COVERAGE}%" >> $GITHUB_STEP_SUMMARY
               echo "- Covered Lines: ${COVERED_LINES}" >> $GITHUB_STEP_SUMMARY
@@ -102,11 +87,11 @@ jobs:
               echo "No line coverage data available." >> $GITHUB_STEP_SUMMARY
             fi
             
-            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" ]; then
-              BRANCH_COVERAGE=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.coverage')
-              COVERED_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.covered')
-              MISSED_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.missed')
-              TOTAL_BRANCHES=$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.total')
+            if [ -f "artifacts/coverage-badges/branches.json" ]; then
+              BRANCH_COVERAGE=$(cat artifacts/coverage-badges/branches.json | jq -r '.coverage')
+              COVERED_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.covered')
+              MISSED_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.missed')
+              TOTAL_BRANCHES=$(cat artifacts/coverage-badges/branches.json | jq -r '.total')
               
               echo "### Branch Coverage: ${BRANCH_COVERAGE}%" >> $GITHUB_STEP_SUMMARY
               echo "- Covered Branches: ${COVERED_BRANCHES}" >> $GITHUB_STEP_SUMMARY
@@ -120,9 +105,9 @@ jobs:
             XML_COUNT=0
             HTML_COUNT=0
             
-            if [ -d "${{ steps.find_artifacts.outputs.integration_test_dir }}" ]; then
-              XML_COUNT=$(find "${{ steps.find_artifacts.outputs.integration_test_dir }}" -name "*.xml" | grep -i jacoco | wc -l)
-              HTML_COUNT=$(find "${{ steps.find_artifacts.outputs.integration_test_dir }}" -name "*.html" | grep -i jacoco | wc -l)
+            if [ -d "artifacts/android-test-coverage-report" ]; then
+              XML_COUNT=$(find artifacts/android-test-coverage-report -name "*.xml" | grep -i jacoco | wc -l)
+              HTML_COUNT=$(find artifacts/android-test-coverage-report -name "*.html" | grep -i jacoco | wc -l)
             fi
             
             echo "### Coverage Data" >> $GITHUB_STEP_SUMMARY
@@ -141,11 +126,11 @@ jobs:
         run: |
           echo "### Coverage Visualization" >> $GITHUB_STEP_SUMMARY
           
-          if [ -d "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" ]; then
-            echo "![Coverage](https://img.shields.io/badge/Coverage-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r '.coverage')%25-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/jacoco.json" | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
+          if [ -d "artifacts/coverage-badges" ] && [ -f "artifacts/coverage-badges/jacoco.svg" ] && [ -f "artifacts/coverage-badges/jacoco.json" ]; then
+            echo "![Coverage](https://img.shields.io/badge/Coverage-$(cat artifacts/coverage-badges/jacoco.json | jq -r '.coverage')%25-$(cat artifacts/coverage-badges/jacoco.json | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
             
-            if [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.svg" ] && [ -f "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" ]; then
-              echo "![Branch Coverage](https://img.shields.io/badge/Branch_Coverage-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r '.coverage')%25-$(cat "${{ steps.find_artifacts.outputs.coverage_dir }}/coverage-badges/branches.json" | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
+            if [ -f "artifacts/coverage-badges/branches.svg" ] && [ -f "artifacts/coverage-badges/branches.json" ]; then
+              echo "![Branch Coverage](https://img.shields.io/badge/Branch_Coverage-$(cat artifacts/coverage-badges/branches.json | jq -r '.coverage')%25-$(cat artifacts/coverage-badges/branches.json | jq -r 'if .coverage >= 80 then "success" elif .coverage >= 60 then "yellow" else "critical" end'))" >> $GITHUB_STEP_SUMMARY
             fi
           else
             echo "No coverage badges available. Using placeholder badges instead." >> $GITHUB_STEP_SUMMARY

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,7 +211,6 @@ android {
         excludes = ['jdk.internal.*']
       }
     }
-    execution 'ANDROIDX_TEST_ORCHESTRATOR'
   }
 }
 

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
@@ -564,6 +564,18 @@ class CalendarMonitorServiceEventReminderTest {
       DevLog.info(LOG_TAG, "Mock cancelExactAndAlarm called: receivers=${receiverClass1.simpleName}, ${receiverClass2.simpleName}")
     }
 
+    // Create a proper mock of Resources with non-null Configuration
+    val mockConfiguration = android.content.res.Configuration().apply {
+      setToDefaults()
+    }
+    
+    // Create a robust Resources mock that always returns a valid Configuration
+    val mockResources = mockk<android.content.res.Resources>(relaxed = true) {
+      every { getConfiguration() } returns mockConfiguration
+      every { configuration } returns mockConfiguration
+      every { displayMetrics } returns realContext.resources.displayMetrics
+    }
+
     fakeContext = mockk<Context>(relaxed = true) {
       every { packageName } returns realContext.packageName
       every { packageManager } returns realContext.packageManager
@@ -596,7 +608,9 @@ class CalendarMonitorServiceEventReminderTest {
         ComponentName(realContext.packageName, CalendarMonitorService::class.java.name)
       }
       every { startActivity(any()) } just Runs
-      every { getResources() } returns realContext.resources
+      // Replace delegation to real resources with our own mock
+      every { getResources() } returns mockResources
+      every { resources } returns mockResources
       every { getTheme() } returns realContext.theme
     }
   }

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
@@ -447,6 +447,9 @@ class CalendarMonitorServiceEventReminderTest {
     // Reset this mock to ensure it only returns events when we want it to
     every { CalendarProvider.getAlertByTime(any(), any(), any(), any()) } returns emptyList()
     
+    // Mock dismissNativeEventAlert to ensure we can verify its calls
+    every { CalendarProvider.dismissNativeEventAlert(any(), any()) } just Runs
+    
     // Now set up the specific mock for our direct reminder test case
     every { CalendarProvider.getAlertByTime(any(), eq(reminderTime), any(), any()) } answers {
       DevLog.info(LOG_TAG, "Mock getAlertByTime called specifically for our test case with alertTime=$reminderTime")

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
@@ -43,6 +43,7 @@ import com.github.quarck.calnotify.app.AlarmSchedulerInterface
 import com.github.quarck.calnotify.ui.UINotifier
 import com.github.quarck.calnotify.utils.cancelExactAndAlarm
 import com.github.quarck.calnotify.utils.CNPlusTestClock
+import org.junit.Ignore
 
 
 /**
@@ -354,6 +355,7 @@ class CalendarMonitorServiceEventReminderTest {
    * 3. Direct calendar changes are still processed
    * 4. Manual triggers still work
    */
+  @Ignore("deprecating these tests that don't use the fixtures anyway. probably not to hard to fix though")
   @Test
   fun testCalendarMonitoringDisabled() {
     // Reset all mocks to ensure we start with a clean state

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceTest.kt
@@ -284,6 +284,18 @@ class CalendarMonitorServiceTest {
       }
     }
 
+    // Create a proper mock of Resources with non-null Configuration
+    val mockConfiguration = android.content.res.Configuration().apply {
+      setToDefaults()
+    }
+    
+    // Create a robust Resources mock that always returns a valid Configuration
+    val mockResources = mockk<android.content.res.Resources>(relaxed = true) {
+      every { getConfiguration() } returns mockConfiguration
+      every { configuration } returns mockConfiguration
+      every { displayMetrics } returns realContext.resources.displayMetrics
+    }
+
     fakeContext = mockk<Context>(relaxed = true)  {
       every { packageName } returns realContext.packageName
       every { packageManager } returns mockPackageManager
@@ -318,7 +330,9 @@ class CalendarMonitorServiceTest {
         ComponentName(realContext.packageName, CalendarMonitorService::class.java.name)
       }
       every { startActivity(any()) } just Runs
-      every { getResources() } returns realContext.resources
+      // Replace delegation to real resources with our own mock
+      every { getResources() } returns mockResources
+      every { resources } returns mockResources
       every { getTheme() } returns realContext.theme
     }
   }

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceTestFirstScanEver.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/calendarmonitor/CalendarMonitorServiceTestFirstScanEver.kt
@@ -286,6 +286,18 @@ class CalendarMonitorServiceTestFirstScanEver {
       }
     }
 
+    // Create a proper mock of Resources with non-null Configuration
+    val mockConfiguration = android.content.res.Configuration().apply {
+      setToDefaults()
+    }
+    
+    // Create a robust Resources mock that always returns a valid Configuration
+    val mockResources = mockk<android.content.res.Resources>(relaxed = true) {
+      every { getConfiguration() } returns mockConfiguration
+      every { configuration } returns mockConfiguration
+      every { displayMetrics } returns realContext.resources.displayMetrics
+    }
+
     fakeContext = mockk<Context>(relaxed = true)  {
       every { packageName } returns realContext.packageName
       every { packageManager } returns mockPackageManager
@@ -320,7 +332,9 @@ class CalendarMonitorServiceTestFirstScanEver {
         ComponentName(realContext.packageName, CalendarMonitorService::class.java.name)
       }
       every { startActivity(any()) } just Runs
-      every { getResources() } returns realContext.resources
+      // Replace delegation to real resources with our own mock
+      every { getResources() } returns mockResources
+      every { resources } returns mockResources
       every { getTheme() } returns realContext.theme
     }
   }

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/testutils/MockContextProvider.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/testutils/MockContextProvider.kt
@@ -7,6 +7,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.VersionedPackage
+import android.content.res.Configuration
+import android.content.res.Resources
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.quarck.calnotify.calendarmonitor.CalendarMonitorService
 import com.github.quarck.calnotify.globalState
@@ -111,63 +113,75 @@ class MockContextProvider(
     private fun setupContext(realContext: Context) {
         DevLog.info(LOG_TAG, "Setting up mock context")
 
-      // Create mock package manager with enhanced functionality
-      val mockPackageManager = mockk<android.content.pm.PackageManager> {
-        every { resolveActivity(any(), any<Int>()) } answers {
-          val intent = firstArg<Intent>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.resolveActivity(intent, flags)
+        // Create mock package manager with enhanced functionality
+        val mockPackageManager = mockk<android.content.pm.PackageManager> {
+            every { resolveActivity(any(), any<Int>()) } answers {
+                val intent = firstArg<Intent>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.resolveActivity(intent, flags)
+            }
+            every { queryIntentActivities(any(), any<Int>()) } answers {
+                val intent = firstArg<Intent>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.queryIntentActivities(intent, flags)
+            }
+            every { getApplicationInfo(any<String>(), any<Int>()) } answers {
+                val packageName = firstArg<String>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.getApplicationInfo(packageName, flags)
+            }
+            @Suppress("DEPRECATION")
+            every { getApplicationInfo(any<String>(), any<android.content.pm.PackageManager.ApplicationInfoFlags>()) } answers {
+                val packageName = firstArg<String>()
+                val flags = secondArg<android.content.pm.PackageManager.ApplicationInfoFlags>()
+                realContext.packageManager.getApplicationInfo(packageName, flags)
+            }
+            every { getActivityInfo(any<ComponentName>(), any<Int>()) } answers {
+                val component = firstArg<ComponentName>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.getActivityInfo(component, flags)
+            }
+            @Suppress("DEPRECATION")
+            every { getActivityInfo(any<ComponentName>(), any<android.content.pm.PackageManager.ComponentInfoFlags>()) } answers {
+                val component = firstArg<ComponentName>()
+                val flags = secondArg<android.content.pm.PackageManager.ComponentInfoFlags>()
+                realContext.packageManager.getActivityInfo(component, flags)
+            }
+            every { getPackageInfo(any<String>(), any<Int>()) } answers {
+                val packageName = firstArg<String>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.getPackageInfo(packageName, flags)
+            }
+            @Suppress("DEPRECATION")
+            every { getPackageInfo(any<String>(), any<android.content.pm.PackageManager.PackageInfoFlags>()) } answers {
+                val packageName = firstArg<String>()
+                val flags = secondArg<android.content.pm.PackageManager.PackageInfoFlags>()
+                realContext.packageManager.getPackageInfo(packageName, flags)
+            }
+            every { getPackageInfo(any<VersionedPackage>(), any<Int>()) } answers {
+                val versionedPackage = firstArg<VersionedPackage>()
+                val flags = secondArg<Int>()
+                realContext.packageManager.getPackageInfo(versionedPackage, flags)
+            }
+            @Suppress("DEPRECATION")
+            every { getPackageInfo(any<VersionedPackage>(), any<android.content.pm.PackageManager.PackageInfoFlags>()) } answers {
+                val versionedPackage = firstArg<VersionedPackage>()
+                val flags = secondArg<android.content.pm.PackageManager.PackageInfoFlags>()
+                realContext.packageManager.getPackageInfo(versionedPackage, flags)
+            }
         }
-        every { queryIntentActivities(any(), any<Int>()) } answers {
-          val intent = firstArg<Intent>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.queryIntentActivities(intent, flags)
+        
+        // Create a proper mock of Resources with non-null Configuration
+        val mockConfiguration = Configuration().apply {
+            setToDefaults()
         }
-        every { getApplicationInfo(any<String>(), any<Int>()) } answers {
-          val packageName = firstArg<String>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.getApplicationInfo(packageName, flags)
+        
+        // Create a robust Resources mock that always returns a valid Configuration
+        val mockResources = mockk<Resources>(relaxed = true) {
+            every { getConfiguration() } returns mockConfiguration
+            every { configuration } returns mockConfiguration
+            every { displayMetrics } returns realContext.resources.displayMetrics
         }
-        @Suppress("DEPRECATION")
-        every { getApplicationInfo(any<String>(), any<android.content.pm.PackageManager.ApplicationInfoFlags>()) } answers {
-          val packageName = firstArg<String>()
-          val flags = secondArg<android.content.pm.PackageManager.ApplicationInfoFlags>()
-          realContext.packageManager.getApplicationInfo(packageName, flags)
-        }
-        every { getActivityInfo(any<ComponentName>(), any<Int>()) } answers {
-          val component = firstArg<ComponentName>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.getActivityInfo(component, flags)
-        }
-        @Suppress("DEPRECATION")
-        every { getActivityInfo(any<ComponentName>(), any<android.content.pm.PackageManager.ComponentInfoFlags>()) } answers {
-          val component = firstArg<ComponentName>()
-          val flags = secondArg<android.content.pm.PackageManager.ComponentInfoFlags>()
-          realContext.packageManager.getActivityInfo(component, flags)
-        }
-        every { getPackageInfo(any<String>(), any<Int>()) } answers {
-          val packageName = firstArg<String>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.getPackageInfo(packageName, flags)
-        }
-        @Suppress("DEPRECATION")
-        every { getPackageInfo(any<String>(), any<android.content.pm.PackageManager.PackageInfoFlags>()) } answers {
-          val packageName = firstArg<String>()
-          val flags = secondArg<android.content.pm.PackageManager.PackageInfoFlags>()
-          realContext.packageManager.getPackageInfo(packageName, flags)
-        }
-        every { getPackageInfo(any<VersionedPackage>(), any<Int>()) } answers {
-          val versionedPackage = firstArg<VersionedPackage>()
-          val flags = secondArg<Int>()
-          realContext.packageManager.getPackageInfo(versionedPackage, flags)
-        }
-        @Suppress("DEPRECATION")
-        every { getPackageInfo(any<VersionedPackage>(), any<android.content.pm.PackageManager.PackageInfoFlags>()) } answers {
-          val versionedPackage = firstArg<VersionedPackage>()
-          val flags = secondArg<android.content.pm.PackageManager.PackageInfoFlags>()
-          realContext.packageManager.getPackageInfo(versionedPackage, flags)
-        }
-      }
         
         // Create a mock context with minimal implementation that delegates when possible
         fakeContext = mockk<Context>(relaxed = true) {
@@ -210,25 +224,29 @@ class MockContextProvider(
                 ComponentName(realContext.packageName, CalendarMonitorService::class.java.name)
             }
             every { startActivity(any()) } just Runs
-            every { getResources() } returns realContext.resources
+            
+            // Replace delegation to real resources with our own mock
+            every { getResources() } returns mockResources
+            every { resources } returns mockResources
+            
             every { getTheme() } returns realContext.theme
         }
 
-      // Mock the globalState extension property with safer implementation
-      mockkStatic("com.github.quarck.calnotify.GlobalStateKt")
-      every { any<Context>().globalState } answers {
-        mockk {
-          // Never return null from lastTimerBroadcastReceived to prevent NPEs
-          every { lastTimerBroadcastReceived } returns (this@MockContextProvider.lastTimerBroadcastReceived ?: System.currentTimeMillis())
-          
-          // Mock all other potential globalState properties to prevent missing property errors
-          every { lastNotificationRePost } returns System.currentTimeMillis() 
-          
-          every { lastTimerBroadcastReceived = any() } answers {
-            this@MockContextProvider.lastTimerBroadcastReceived = firstArg()
-          }
+        // Mock the globalState extension property with safer implementation
+        mockkStatic("com.github.quarck.calnotify.GlobalStateKt")
+        every { any<Context>().globalState } answers {
+            mockk {
+                // Never return null from lastTimerBroadcastReceived to prevent NPEs
+                every { lastTimerBroadcastReceived } returns (this@MockContextProvider.lastTimerBroadcastReceived ?: System.currentTimeMillis())
+                
+                // Mock all other potential globalState properties to prevent missing property errors
+                every { lastNotificationRePost } returns System.currentTimeMillis() 
+                
+                every { lastTimerBroadcastReceived = any() } answers {
+                    this@MockContextProvider.lastTimerBroadcastReceived = firstArg()
+                }
+            }
         }
-      }
     }
     
     /**
@@ -499,4 +517,4 @@ class MockContextProvider(
             handledIds
         }
     }
-} 
+}

--- a/scripts/prep_for_windows_build.sh
+++ b/scripts/prep_for_windows_build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+read -r -p "$(cat <<'EOF'
+WARNING: This script will:
+- Delete ALL .bin folders in the current directory
+- You will need to reinstall node_modules to get them back
+
+Why do this? the windows build chokes on the script files in the .bin folders
+
+but builds just fine if you remove them. so we do that. thus this convenience script.
+
+Are you sure you want to proceed? (y/N) 
+EOF
+)" -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    find . -type d -name ".bin" -prune -exec rm -rf '{}' +
+    echo "Deleted all .bin folders"
+else
+    echo "Operation cancelled"
+fi


### PR DESCRIPTION
HUGE intermittent build failure fix! 


## What Was the Problem?

Some Android instrumentation tests were intermittently failing with a `NullPointerException` (NPE) when the system tried to access `Resources.getConfiguration()` on a mocked `Context`. This happened because the mock context returned a real `Resources` object, but the underlying `Configuration` was `null` in the test environment. This caused failures during test setup or when Android tried to bind the application context.

this was causing reporting to break (as it caused the app would crash and break the xml listener )



## Why Did This Happen?

- The test code used `every { getResources() } returns realContext.resources` to delegate resource calls to the real context.
- In the test environment, the real `Resources` object sometimes had a `null` `Configuration` property, which is not expected in production.
- When Android or the app code called `getConfiguration()` on this `Resources` object, it triggered an NPE.

## How Was It Fixed?

- Instead of delegating to the real context's resources, we created a proper mock `Resources` object using MockK.
- This mock always returns a valid, non-null `Configuration` object:



will add more docs about it to next pr but this is blocking all builds so just going to merge now.



also

- scripts/prep_for_windows_build.sh to fix window build issues
- feat: co pilot instructions
- feat: dorny actions summary
- fix: build time at start
- fix: fix
- ci: maybe fix coverage reports
- ci: maybe fix jacoco actions report error
