### PR TITLE
Show next alert time in notification

### DIFF
--- a/android/app/src/main/java/com/github/quarck/calnotify/Settings.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/Settings.kt
@@ -132,6 +132,9 @@ class Settings(context: Context) : PersistentStorageBase(context), SettingsInter
     val snoozePresetsRaw: String
         get() = getString(SNOOZE_PRESET_KEY, DEFAULT_SNOOZE_PRESET)
 
+    val displayNextAlertTime: Boolean
+      get() = getBoolean(DISPLAY_NEXT_ALERT_TIME, false)
+
     val snoozePresets: LongArray
         get() {
             var ret = PreferenceUtils.parseSnoozePresets(snoozePresetsRaw)
@@ -438,6 +441,7 @@ class Settings(context: Context) : PersistentStorageBase(context), SettingsInter
         private const val CALENDAR_IS_HANDLED_KEY_PREFIX = "calendar_handled_"
 
         private const val SNOOZE_PRESET_KEY = "pref_snooze_presets" //"15m, 1h, 4h, 1d"
+        private const val DISPLAY_NEXT_ALERT_TIME = "pref_display_next_alert_time" //false
         private const val VIEW_AFTER_EDIT_KEY = "show_event_after_reschedule" // true
         private const val ENABLE_REMINDERS_KEY = "enable_reminding_key" // false
         private const val REMINDER_INTERVAL_PATTERN_KEY = "remind_interval_key_pattern" // "10m"

--- a/android/app/src/main/java/com/github/quarck/calnotify/calendar/EventRecord.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/calendar/EventRecord.kt
@@ -168,3 +168,11 @@ fun EventRecord.nextAlarmTime(currentTime: Long): Long {
 
     return ret
 }
+
+fun EventRecord.getNextAlertTimeAfter(anchor: Long): Long? {
+    val futureReminders = this
+        .reminders
+        .map { this.startTime - it.millisecondsBefore }
+        .filter { it > anchor }
+    return futureReminders.maxOrNull()
+}

--- a/android/app/src/main/java/com/github/quarck/calnotify/textutils/EventFormatter.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/textutils/EventFormatter.kt
@@ -22,10 +22,13 @@ package com.github.quarck.calnotify.textutils
 import android.content.Context
 import android.text.format.DateUtils
 import com.github.quarck.calnotify.Consts
+import com.github.quarck.calnotify.Settings
 import com.github.quarck.calnotify.R
 import com.github.quarck.calnotify.calendar.EventAlertRecord
 import com.github.quarck.calnotify.calendar.displayedEndTime
 import com.github.quarck.calnotify.calendar.displayedStartTime
+import com.github.quarck.calnotify.calendar.CalendarProviderInterface
+import com.github.quarck.calnotify.calendar.CalendarProvider
 import com.github.quarck.calnotify.utils.DateTimeUtils
 import com.github.quarck.calnotify.utils.CNPlusClockInterface
 import com.github.quarck.calnotify.utils.CNPlusSystemClock
@@ -63,6 +66,7 @@ class EventFormatter(
 ) : EventFormatterInterface {
 
     private val defaultLocale by lazy { Locale.getDefault() }
+    private val calendarProvider: CalendarProviderInterface = CalendarProvider
 
 
     private fun formatDateRangeUTC(startMillis: Long, endMillis: Long, flags: Int): String {
@@ -78,6 +82,21 @@ class EventFormatter(
         val sb = StringBuilder()
 
         sb.append(formatDateTimeOneLine(event, false))
+
+        if (Settings(ctx).displayNextAlertTime) {
+            val eventRecord = calendarProvider.getEvent(ctx, event.eventId)
+            val nextAlertTime = eventRecord.getNextAlertTimeAfter(event.displayedStartTime)
+            if (nextAlertTime != null) {
+                val duration = nextAlertTime - clock.currentTimeMillis()
+                if (duration > 0) {
+                    sb.append(" (")
+                    sb.append(ctx.getString(R.string.event_next_alert_in))
+                    sb.append(" ")
+                    sb.append(formatTimeDuration(duration, 60))
+                    sb.append(")")
+                }
+            }
+        }
 
         if (event.location != "") {
             sb.append("\n")

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -191,6 +191,7 @@
     <string name="dismissed_from_notification" formatted="false">Dismissed via notification %s</string>
     <string name="event_moved_new_time" formatted="false">Moved, new time: %s</string>
     <string name="event_rescheduled_new_time" formatted="false">Confirmed Rescheduled on %s</string>
+    <string name="event_next_alert_in" formatted="false">Next alert in %s</string>
     <string name="restore">Restore notification</string>
     <string name="swipe_to_delete">Swipe to delete from history</string>
     <string name="remove_all">Remove all</string>


### PR DESCRIPTION
This shows the next alert time (if setting enabled, and if there is a next alert time), in the notification

Closes #89

Todo:
- [x] Pass through `EventRecord` to `EventFormatter.formatNotificationSecondaryText()`
- [x] Add setting UI