### PR TITLE
fix: sync debug view performance

### DIFF
--- a/lib/hooks/SyncDebugContext.tsx
+++ b/lib/hooks/SyncDebugContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { 
   subscribeSyncLogs, 
   getFailedOperations, 
@@ -11,7 +12,10 @@ import {
   LogFilterLevel,
 } from '../powersync/Connector';
 
-const MAX_LOG_ENTRIES = 2000;
+const MAX_LOG_ENTRIES_MEMORY = 2000;  // Keep more in memory for current session
+const MAX_LOG_ENTRIES_STORAGE = 500;  // Persist fewer to avoid storage bloat
+const LOGS_STORAGE_KEY = '@powersync_debug_logs';
+const SAVE_DEBOUNCE_MS = 2000;  // Debounce saves to avoid excessive writes
 
 interface SyncDebugContextType {
   logs: SyncLogEntry[];
@@ -31,23 +35,71 @@ export const SyncDebugProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   const [failedOperations, setFailedOperations] = useState<FailedOperation[]>([]);
   const [logFilterLevel, setLogFilterLevelState] = useState<LogFilterLevel>(getLogFilterLevel());
   const logsRef = useRef<SyncLogEntry[]>([]);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isLoadedRef = useRef(false);
+
+  // Debounced save to AsyncStorage
+  const scheduleSave = useCallback((logsToSave: SyncLogEntry[]) => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(async () => {
+      try {
+        // Only persist the most recent entries to storage
+        const toStore = logsToSave.slice(0, MAX_LOG_ENTRIES_STORAGE);
+        await AsyncStorage.setItem(LOGS_STORAGE_KEY, JSON.stringify(toStore));
+      } catch {
+        // Ignore storage errors
+      }
+    }, SAVE_DEBOUNCE_MS);
+  }, []);
 
   const setLogFilterLevel = useCallback((level: LogFilterLevel) => {
     setFilterLevel(level);
     setLogFilterLevelState(level);
   }, []);
 
+  // Load persisted logs on mount
+  useEffect(() => {
+    const loadLogs = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(LOGS_STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as SyncLogEntry[];
+          logsRef.current = parsed;
+          setLogs(parsed);
+        }
+      } catch {
+        // Ignore load errors
+      }
+      isLoadedRef.current = true;
+    };
+    loadLogs();
+
+    // Cleanup save timeout on unmount
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // Subscribe to sync log events
   useEffect(() => {
     const unsubscribe = subscribeSyncLogs((entry) => {
       // Use ref to avoid stale closure issues
-      const newLogs = [entry, ...logsRef.current].slice(0, MAX_LOG_ENTRIES);
+      const newLogs = [entry, ...logsRef.current].slice(0, MAX_LOG_ENTRIES_MEMORY);
       logsRef.current = newLogs;
       setLogs(newLogs);
+      
+      // Schedule save to storage (only after initial load)
+      if (isLoadedRef.current) {
+        scheduleSave(newLogs);
+      }
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [scheduleSave]);
 
   // Load failed operations on mount
   useEffect(() => {
@@ -58,9 +110,14 @@ export const SyncDebugProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     loadFailedOps();
   }, []);
 
-  const clearLogs = useCallback(() => {
+  const clearLogs = useCallback(async () => {
     logsRef.current = [];
     setLogs([]);
+    try {
+      await AsyncStorage.removeItem(LOGS_STORAGE_KEY);
+    } catch {
+      // Ignore errors
+    }
   }, []);
 
   const refreshFailedOperations = useCallback(async () => {


### PR DESCRIPTION
## 1. FlatList Virtualization (`App/SyncDebug.tsx`)
- Replaced `ScrollView` with `FlatList` - only renders visible items
- Added `memo()` to `LogEntryView` to prevent unnecessary re-renders
- Performance settings: `removeClippedSubviews`, `maxToRenderPerBatch=20`, `windowSize=10`
- Status, filter, and failed ops rendered as `ListHeaderComponent`

## 2. Log Persistence (`lib/hooks/SyncDebugContext.tsx`)
- **Memory limit**: 2000 entries (for current session)
- **Storage limit**: 500 entries (persisted to AsyncStorage)
- **Debounced saves**: 2 seconds delay to avoid excessive writes
- Loads persisted logs on app start
- `clearLogs()` also clears storage

The logs will now survive app restarts (up to 500), and scrolling through thousands of logs should be smooth since only visible items are rendered.