### PR TITLE
test: grant more permissions dissmis faster

### DIFF
--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityTest.kt
@@ -36,7 +36,8 @@ class MainActivityTest : BaseUltronTest() {
         // Prevent calendar reloads that would clear test events from EventsStorage
         // This is a lightweight mock that just stops ApplicationController.onMainActivityResumed
         // from triggering background calendar scans
-        fixture.setup(preventCalendarReload = true)
+        // Grant permissions to avoid permission dialogs (faster tests)
+        fixture.setup(preventCalendarReload = true, grantPermissions = true)
     }
     
     @After

--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/ViewEventActivityTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/ViewEventActivityTest.kt
@@ -34,7 +34,7 @@ class ViewEventActivityTest : BaseUltronTest() {
         fixture = UITestFixture.create()
         // Grant permissions programmatically so ViewEventActivity doesn't finish() immediately
         // This allows the test to work in isolation while other tests can still test permission dialogs
-        fixture.setup(grantCalendarPermissions = true)
+        fixture.setup(grantPermissions = true)
     }
     
     @After


### PR DESCRIPTION
## Changes Made

**UITestFixture.kt:**
- Renamed `grantCalendarPermissions` → `grantPermissions` (parameter and method)
- Updated documentation to reflect it grants calendar + notifications
- Reduced timeouts:
  - `FIRST_DIALOG_TIMEOUT_MS`: 500ms → 300ms
  - `SUBSEQUENT_DIALOG_TIMEOUT_MS`: 200ms → 100ms  
  - `DIALOG_DISMISS_ANIMATION_MS`: 150ms → 100ms

**MainActivityTest.kt:**
- Now uses `grantPermissions = true` in addition to `preventCalendarReload = true`

**ViewEventActivityTest.kt:**
- Updated to use new parameter name `grantPermissions = true`

## Timeout Impact

**Before (no dialogs, worst case):** 500 + (4 × 200) + (5 × 150) = ~1.8 seconds per test

**After (no dialogs, worst case):** 300 + (4 × 100) + (5 × 100) = ~1.2 seconds per test

With permissions granted upfront, the dismissal should exit early on first check (no dialogs found), so actual overhead is just ~300ms per test.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename and broaden permission helper to grant calendar+notifications, update tests to use it, and reduce dialog dismissal timeouts for faster runs.
> 
> - **Test utils (`UITestFixture.kt`)**:
>   - Rename `grantCalendarPermissions` → `grantPermissions`; now grants `READ_CALENDAR`, `WRITE_CALENDAR`, and `POST_NOTIFICATIONS` (API 33+).
>   - Add `grantPermissions` setup flag and corresponding runtime permission granting.
>   - Shorten dialog dismissal timeouts (`FIRST_DIALOG_TIMEOUT_MS` 500→300, `SUBSEQUENT_DIALOG_TIMEOUT_MS` 200→100, `DIALOG_DISMISS_ANIMATION_MS` 150→100).
> - **Tests**:
>   - Update `MainActivityTest.kt` and `ViewEventActivityTest.kt` to call `fixture.setup(..., grantPermissions = true)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3fbd3ed29a766f019911613d5dafaafad74d698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->