### PR TITLE
ci: cache update logic

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -165,8 +165,10 @@ runs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4.0.0
       with:
-        cache-read-only: ${{ !(github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.number == 79)) }}
-        cache-overwrite-existing: ${{ !(github.ref == 'refs/heads/master' || (github.event_name == 'pull_request' && github.event.pull_request.number == 79)) }}
+        # Cache is writeable for: tag builds (to update after release) and manual dispatch from master (to refresh cache)
+        # Cache is read-only for: PRs and manual dispatch from other branches
+        cache-read-only: ${{ !(github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
+        cache-overwrite-existing: ${{ !(github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
         gradle-home-cache-cleanup: true
         gradle-home-cache-includes: |
           caches


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Gradle cache settings so writes occur on master and tags; PRs/other branches are read-only.
> 
> - **CI (GitHub Actions)**
>   - **Gradle Cache Policy**: In `/.github/actions/common-setup/action.yml`, update `setup-gradle@v4.0.0` config to make cache writeable on `master` and tags, and read-only for PRs/other branches (`cache-read-only` and `cache-overwrite-existing` conditions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7dc761b536c643ede376f08dd973c1339ee2aa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->