### PR TITLE
test: fix local flakiness in notification dismiss

### DIFF
--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityTest.kt
@@ -298,7 +298,6 @@ class MainActivityTest : BaseUltronTest() {
     
     @Test
     fun search_filters_events() {
-        fixture.cancelAllNotifications()
         fixture.createEvent(title = "Alpha Meeting")
         fixture.createEvent(title = "Beta Meeting")
         
@@ -324,7 +323,6 @@ class MainActivityTest : BaseUltronTest() {
     
     @Test
     fun first_back_press_hides_keyboard_keeps_filter() {
-        fixture.cancelAllNotifications()
         fixture.createEvent(title = "Alpha Meeting")
         fixture.createEvent(title = "Beta Meeting")
         
@@ -356,7 +354,6 @@ class MainActivityTest : BaseUltronTest() {
     
     @Test
     fun second_back_press_clears_filter() {
-        fixture.cancelAllNotifications()
         fixture.createEvent(title = "Alpha Meeting")
         fixture.createEvent(title = "Beta Meeting")
         


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves UI test stability by isolating alarm-driven notifications and auto-clearing them when running with mocked calendar reloads.
> 
> - In `UITestFixture.setupCalendarReloadPrevention()`, mock `ApplicationController.onEventAlarm(...)` and `ApplicationController.fireEventReminder(...)` to prevent stale `AlarmManager` notifications from affecting tests; continue mocking `onMainActivityResumed(...)` and `onCalendarChanged(...)`
> - In `launchMainActivity()`, when reload prevention is active, call `cancelAllNotifications()` after dismissing dialogs to avoid UI interference (e.g., blocked toolbar)
> - Remove redundant `fixture.cancelAllNotifications()` calls in `MainActivityTest` search tests, relying on centralized cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b30d01cfc0880dd4d0366ca5d7466e0c9e5eca4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->