### PR TITLE
fix: back search persist on newer devices

### DIFF
--- a/android/app/src/test/java/com/github/quarck/calnotify/ui/MainActivityRobolectricTest.kt
+++ b/android/app/src/test/java/com/github/quarck/calnotify/ui/MainActivityRobolectricTest.kt
@@ -264,7 +264,7 @@ class MainActivityRobolectricTest {
     // === Search Back Button Tests ===
     
     @Test
-    fun search_filter_persists_when_searchview_has_focus_and_back_pressed() {
+    fun search_filter_persists_when_searchview_has_focus_and_collapse_attempted() {
         fixture.createEvent(title = "Alpha Event")
         fixture.createEvent(title = "Beta Event")
         
@@ -280,9 +280,11 @@ class MainActivityRobolectricTest {
             
             // Expand SearchView and give it focus (simulates user tapping search icon)
             val searchView = activity.searchView
+            val searchMenuItem = activity.searchMenuItem
             assertNotNull("SearchView should be initialized", searchView)
-            searchView!!.setIconified(false)
-            searchView.requestFocus()
+            assertNotNull("SearchMenuItem should be initialized", searchMenuItem)
+            searchMenuItem!!.expandActionView()
+            searchView!!.requestFocus()
             searchView.setQuery("Alpha", false)
             shadowOf(Looper.getMainLooper()).idle()
             
@@ -290,11 +292,11 @@ class MainActivityRobolectricTest {
             assertEquals("Alpha", adapter.searchString)
             assertTrue("SearchView should have focus", searchView.hasFocus())
             
-            // Press back - should clear focus but keep filter
-            activity.onBackPressedDispatcher.onBackPressed()
+            // Try to collapse (simulates back press) - should clear focus but prevent collapse
+            searchMenuItem.collapseActionView()
             shadowOf(Looper.getMainLooper()).idle()
             
-            // Filter should still be active
+            // Filter should still be active, SearchView should still be expanded
             assertEquals("Alpha", adapter.searchString)
             assertEquals(1, adapter.itemCount)
         }
@@ -303,7 +305,7 @@ class MainActivityRobolectricTest {
     }
     
     @Test
-    fun search_filter_clears_on_back_when_no_focus() {
+    fun search_filter_clears_on_collapse_when_no_focus() {
         fixture.createEvent(title = "Alpha Event")
         fixture.createEvent(title = "Beta Event")
         
@@ -319,17 +321,19 @@ class MainActivityRobolectricTest {
             
             // Set search via SearchView but clear focus (simulates submitted search)
             val searchView = activity.searchView
+            val searchMenuItem = activity.searchMenuItem
             assertNotNull(searchView)
-            searchView!!.setIconified(false)
-            searchView.setQuery("Alpha", false)
+            assertNotNull(searchMenuItem)
+            searchMenuItem!!.expandActionView()
+            searchView!!.setQuery("Alpha", false)
             searchView.clearFocus()
             shadowOf(Looper.getMainLooper()).idle()
             
             assertEquals(1, adapter.itemCount)
             assertFalse("SearchView should not have focus", searchView.hasFocus())
             
-            // Back press should clear filter (no focus to clear first)
-            activity.onBackPressedDispatcher.onBackPressed()
+            // Collapse should clear filter (no focus to clear first)
+            searchMenuItem.collapseActionView()
             shadowOf(Looper.getMainLooper()).idle()
             
             // Filter should be cleared


### PR DESCRIPTION
## 1. What Was Wrong

**The core issue:** `OnBackPressedCallback` doesn't intercept *all* back presses. The ActionBar/Toolbar has its **own** back press handling for collapsing expanded ActionViews that runs at a lower level.

**The back press chain looks like this:**

```
User presses back
       ↓
┌─────────────────────────────────────┐
│  ActionBar/Toolbar checks:          │  ← Happens FIRST
│  "Is there an expanded ActionView?" │
│  If yes → collapse it, DONE         │
└─────────────────────────────────────┘
       ↓ (only if no ActionView)
┌─────────────────────────────────────┐
│  OnBackPressedDispatcher            │  ← Our callback lives here
│  Calls registered callbacks         │
└─────────────────────────────────────┘
       ↓
┌─────────────────────────────────────┐
│  Default behavior (finish/bg)       │
└─────────────────────────────────────┘
```

So our `OnBackPressedCallback` never even got called because the ActionBar intercepted the back press first and collapsed the SearchView.

**What OS versions/updates caused this?**

This has technically always been the case, but it became more noticeable with:
- **Android 10 (API 29)**: Gesture navigation became default, back handling got more complex
- **Android 13 (API 33)**: Predictive back animations introduced, more strict back handling
- **Android 14-16**: Further refinements to back gesture system

The old approach of overriding `onBackPressed()` directly might have worked differently because it was at a different point in the chain. AndroidX's `OnBackPressedCallback` is a higher-level abstraction that doesn't cover ActionBar internals.

---

## 2. Could We Have Known?

**Honestly: not easily.** Here's why our tests passed but the device failed:

| Test Type | Why It Passed | Reality |
|-----------|---------------|---------|
| **Robolectric** | Simulates Android but doesn't replicate ActionBar back handling. `onBackPressedDispatcher.onBackPressed()` goes directly to callbacks. | Real ActionBar intercepts first |
| **Instrumentation/Espresso** | Probably ran on emulator with slightly different timing/state, or older Android version | Pixel 9 Pro Fold with latest Android 16 |

**What could have caught this:**
1. **Testing on real flagship devices** with latest OS - exactly what you did
2. **Reading ActionView documentation carefully** - it mentions the collapse-on-back behavior but doesn't explicitly say it bypasses OnBackPressedCallback
3. **Using `OnActionExpandListener` from the start** - this is the documented way to intercept ActionView collapse

**The lesson:** For anything involving system UI (navigation, ActionBar, gestures), Robolectric and even emulators can't fully replicate real device behavior. This is why Google recommends testing on multiple real devices with different OS versions.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements two-stage SearchView dismissal using the action view’s expand/collapse lifecycle, replacing back-press handling.
> 
> - Add `OnActionExpandListener` on `searchMenuItem` to intercept collapse: if `searchView` has focus, clear focus and prevent collapse; otherwise clear active filter and allow collapse
> - Remove custom `OnBackPressedCallback` search logic; back behavior falls through to default when no search
> - Expose `searchMenuItem` as `internal` for tests
> - Update Robolectric tests to drive search via `expandActionView()/collapseActionView()` and assert focus/filter behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63aea76f8b42072d55458b361ba750de6405f104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->