### PR TITLE
fix: snoozed until text dark mode colors

### DIFF
--- a/android/app/src/main/res/layout/event_card_compact.xml
+++ b/android/app/src/main/res/layout/event_card_compact.xml
@@ -101,7 +101,7 @@
             android:id="@+id/card_view_snoozed_until"
             android:text="@string/snoozed_until_example"
             android:textAppearance="?android:textAppearanceSmall"
-            android:textColor="@color/divider"
+            android:textColor="@color/snoozed_until_text"
 
             android:layout_below="@id/card_view_event_date"
             android:layout_toEndOf="@id/compact_view_calendar_color"

--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -22,6 +22,9 @@
     <!-- Dividers (adjusted for dark mode) -->
     <color name="divider">#3D3D3D</color>
     <color name="divider_light">#2D2D2D</color>
+
+    <!-- Snoozed until text - readable but de-emphasized -->
+    <color name="snoozed_until_text">#888888</color>
     <color name="light_divider">#2A2A2A</color>
     <color name="ultra_light_divider">#1F1F1F</color>
 

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -24,6 +24,9 @@
     <color name="divider">#B6B6B6</color>
     <color name="divider_light">#C6C6C6</color>
 
+    <!-- Snoozed until text - soft secondary styling -->
+    <color name="snoozed_until_text">#9E9E9E</color>
+
     <color name="event_title_color">#FFFFFF</color>
     <color name="event_title_hint_color">#CECECE</color>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the "snoozed until" label uses theme-appropriate styling in light and dark modes.
> 
> - Adds `snoozed_until_text` color in `values/colors.xml` and `values-night/colors.xml`
> - Updates `event_card_compact.xml` to use `@color/snoozed_until_text` for `card_view_snoozed_until` instead of `@color/divider`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfb2f96cb0c02d49f09f8e3224b30af87080aa48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->