### PR TITLE
fix: main list color hierarchy in dark mode

### DIFF
--- a/android/app/src/main/res/values-night/colors.xml
+++ b/android/app/src/main/res/values-night/colors.xml
@@ -24,7 +24,7 @@
     <color name="divider_light">#2D2D2D</color>
 
     <!-- Snoozed until text - readable but de-emphasized -->
-    <color name="snoozed_until_text">#888888</color>
+    <color name="snoozed_until_text">#707070</color>
     <color name="light_divider">#2A2A2A</color>
     <color name="ultra_light_divider">#1F1F1F</color>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Minor dark mode visual adjustment to clarify text hierarchy.
> 
> - Updates `snoozed_until_text` color in `android/app/src/main/res/values-night/colors.xml` from `#888888` to `#707070` to improve readability on dark backgrounds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 051237045dce33b4c701759db7f6e2113e7f18dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->