### PR TITLE
fix: mute icon main activity dark mode color

### DIFF
--- a/android/app/src/main/res/layout/event_card_compact.xml
+++ b/android/app/src/main/res/layout/event_card_compact.xml
@@ -128,7 +128,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 card_view:srcCompat="@drawable/ic_volume_off_black_24dp"
-                android:tint="@color/primary_text"
+                card_view:tint="@color/primary_text"
                 android:contentDescription="@string/notification_is_muted"
                 android:layout_marginTop="0dp"
                 android:layout_marginEnd="0dp"
@@ -136,7 +136,6 @@
                 android:visibility="gone"
                 android:scaleX="0.75"
                 android:scaleY="0.75"
-                android:alpha="0.75"
                 />
 
             <ImageView
@@ -144,7 +143,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 card_view:srcCompat="@drawable/ic_event_available_black_24dp"
-                android:tint="@color/primary_text"
+                card_view:tint="@color/primary_text"
                 android:layout_marginTop="0dp"
                 android:layout_marginEnd="0dp"
                 android:padding="0dp"
@@ -152,7 +151,6 @@
                 android:importantForAccessibility="no"
                 android:scaleX="0.75"
                 android:scaleY="0.75"
-                android:alpha="0.75"
                 />
 
             <ImageView
@@ -167,8 +165,7 @@
                 android:scaleY="0.75"
                 android:visibility="gone"
                 card_view:srcCompat="@drawable/ic_alarm_black_24dp"
-                android:tint="@color/primary_text"
-                android:alpha="0.75"
+                card_view:tint="@color/primary_text"
                 />
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves icon visibility in the compact event card, especially in dark mode.
> 
> - In `event_card_compact.xml`, apply `card_view:tint="@color/primary_text"` to `imageview_is_muted_indicator`, `imageview_is_task_indicator`, and `imageview_is_alarm_indicator`
> - Remove `android:alpha="0.75"` from these indicators to avoid faded appearance
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c5e70cd32309c1c17fd9734287e83393f872d48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->