### PR TITLE
fix: double notification sounds on Samsung devices (issue #155)

### DIFF
--- a/android/app/src/main/java/com/github/quarck/calnotify/notification/EventNotificationManager.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/notification/EventNotificationManager.kt
@@ -1011,6 +1011,7 @@ open class EventNotificationManager : EventNotificationManagerInterface {
                 .setSubText(text)
                 .setGroupSummary(true)
                 .setGroup(NOTIFICATION_GROUP)
+                .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
                 .setContentIntent(pendingIntent)
                 .setCategory(
                         NotificationCompat.CATEGORY_EVENT
@@ -1173,6 +1174,7 @@ open class EventNotificationManager : EventNotificationManagerInterface {
 
         if (notificationSettings.useBundledNotifications) {
             builder.setGroup(NOTIFICATION_GROUP)
+            builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
         }
 
         var snoozePresets =
@@ -1536,6 +1538,7 @@ open class EventNotificationManager : EventNotificationManagerInterface {
 
         if (notificationSettings.useBundledNotifications) {
             builder.setGroup(NOTIFICATION_GROUP)
+            builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
         }
 
         if (notificationSettings.led.on && (!isQuietPeriodActive || !settings.quietHoursMuteLED)) {


### PR DESCRIPTION
## Summary

Added `setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)` to three places in `EventNotificationManager.kt`:

### 1. Group Summary Notification (`postGroupNotification`) - line ~1014

```kotlin
val groupBuilder = NotificationCompat.Builder(ctx, NotificationChannels.CHANNEL_ID_DEFAULT)
        .setGroupSummary(true)
        .setGroup(NOTIFICATION_GROUP)
        .setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)  // <-- Added
        // ...
```

### 2. Individual Event Notifications (`postNotification`) - line ~1178

```kotlin
if (notificationSettings.useBundledNotifications) {
    builder.setGroup(NOTIFICATION_GROUP)
    builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)  // <-- Added
}
```

### 3. Partial Collapse Notifications (`postNumNotificationsCollapsed`) - line ~1541

```kotlin
if (notificationSettings.useBundledNotifications) {
    builder.setGroup(NOTIFICATION_GROUP)
    builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)  // <-- Added
}
```

### What This Does

`GROUP_ALERT_CHILDREN` tells Android:
- **Children notifications** (individual events) should be the ones to make sound/vibrate
- **Group summary** should NOT make sound when it appears or updates

This should fix the double notification sound issue on Samsung S22 (Android 16) where:
1. First sound plays when individual event notifications are posted ✓
2. Second sound was playing when Android collapsed them into a group ✗ → Now fixed


---

Add setGroupAlertBehavior(GROUP_ALERT_CHILDREN) to bundled notifications
to prevent group summaries from triggering additional alert sounds.

On Samsung S22 with Android 16, when multiple event notifications were
collapsed into a group, the group summary would trigger a second
notification sound. This fix explicitly tells Android that only child
notifications should alert, not the group summary.

Changes:
- postGroupNotification: Added GROUP_ALERT_CHILDREN to group summary
- postNotification: Added GROUP_ALERT_CHILDREN to individual notifications
- postNumNotificationsCollapsed: Added GROUP_ALERT_CHILDREN to partial collapse

fixes #155

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures grouped notifications only alert on child items, preventing duplicate sounds (e.g., on Samsung devices) when using bundled notifications.
> 
> - Add `setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)` to group summary in `postGroupNotification`
> - Apply the same behavior to individual notifications when `useBundledNotifications` in `postNotification`
> - Apply to partial-collapse summary in `postNumNotificationsCollapsed`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38d1fd7e22faa2442cc335b20b5ad3eac813237e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->