### PR TITLE
fix: back button on some settings screens

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -87,7 +87,7 @@
         <activity
             android:name=".prefs.CalendarsActivity"
             android:label="@string/title_calendars_activity"
-            android:parentActivityName=".ui.SettingsActivity"
+            android:parentActivityName=".ui.SettingsActivityX"
             android:theme="@style/AppTheme.NoActionBar"
             android:exported="true">
             <intent-filter>
@@ -100,7 +100,7 @@
         <activity
             android:name=".prefs.CarModeActivity"
             android:label="@string/title_car_mode_activity"
-            android:parentActivityName=".ui.SettingsActivity"
+            android:parentActivityName=".ui.SettingsActivityX"
             android:theme="@style/AppTheme.NoActionBar"
             android:exported="true">
             <intent-filter>

--- a/android/app/src/main/java/com/github/quarck/calnotify/prefs/CalendarsActivity.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/prefs/CalendarsActivity.kt
@@ -222,6 +222,11 @@ class CalendarsActivity : AppCompatActivity() {
         }
     }
 
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
     companion object {
         private const val LOG_TAG = "CalendarsActivity"
     }

--- a/android/app/src/main/java/com/github/quarck/calnotify/prefs/CarModeActivity.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/prefs/CarModeActivity.kt
@@ -222,6 +222,11 @@ class CarModeActivity : AppCompatActivity() {
         }
     }
 
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
     companion object {
         private const val LOG_TAG = "CarModeActivity"
     }


### PR DESCRIPTION
fixes: #151

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves navigation behavior on settings sub-screens.
> 
> - Add `onSupportNavigateUp()` (calls `finish()`) in `CalendarsActivity.kt` and `CarModeActivity.kt` to make the action bar back/up work
> - Update `AndroidManifest.xml` to set `android:parentActivityName` of `prefs.CalendarsActivity` and `prefs.CarModeActivity` to `ui.SettingsActivityX`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65d69f1cf51c84732988fd8e8b5771fc28ffe1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->