### PR TITLE
fix: event lookahead milestone one fast follow p3

### DIFF
--- a/android/app/src/main/java/com/github/quarck/calnotify/Settings.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/Settings.kt
@@ -455,8 +455,7 @@ class Settings(context: Context) : PersistentStorageBase(context), SettingsInter
         get() = getBoolean(SHOW_NEW_UI_BANNER_KEY, true)
         set(value) = setBoolean(SHOW_NEW_UI_BANNER_KEY, value)
     
-    /** Lookahead mode: "fixed" = fixed hours ahead (default), "day_boundary" = until day boundary.
-     *  Note: "cutoff" is a legacy value - UpcomingEventsLookahead treats it as "day_boundary". */
+    /** Lookahead mode: "fixed" = fixed hours ahead (default), "day_boundary" = until day boundary.*/
     var upcomingEventsMode: String
         get() = getString(UPCOMING_EVENTS_MODE_KEY, "fixed")
         set(value) = setString(UPCOMING_EVENTS_MODE_KEY, value)

--- a/android/app/src/main/java/com/github/quarck/calnotify/upcoming/UpcomingEventsLookahead.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/upcoming/UpcomingEventsLookahead.kt
@@ -25,7 +25,7 @@ import com.github.quarck.calnotify.utils.CNPlusClockInterface
 import java.util.Calendar
 
 /**
- * Calculates the cutoff time for the upcoming events lookahead window.
+ * Calculates the end time for the upcoming events lookahead window.
  * 
  * Supports two modes:
  * - "fixed" (default): Shows events for a fixed number of hours ahead
@@ -41,24 +41,24 @@ class UpcomingEventsLookahead(
 ) {
     
     /**
-     * Get the cutoff time for the upcoming events window.
-     * Events with alertTime between now and this cutoff will be shown.
+     * Get the end time for the upcoming events lookahead window.
+     * Events with alertTime between now and this end time will be shown.
      * 
-     * @return The cutoff time in milliseconds since epoch
+     * @return The lookahead end time in milliseconds since epoch
      */
-    fun getCutoffTime(): Long {
+    fun getLookaheadEndTime(): Long {
         val now = clock.currentTimeMillis()
         
         return when (settings.upcomingEventsMode) {
-            MODE_DAY_BOUNDARY, MODE_CUTOFF -> calculateDayBoundaryCutoff(now)  // "cutoff" is legacy
-            else -> calculateFixedCutoff(now)  // Default to fixed mode
+            MODE_DAY_BOUNDARY -> calculateDayBoundaryEndTime(now)
+            else -> calculateFixedEndTime(now)  // Default to fixed mode
         }
     }
     
     /**
      * Fixed hours lookahead: now + configured hours
      */
-    private fun calculateFixedCutoff(now: Long): Long {
+    private fun calculateFixedEndTime(now: Long): Long {
         val fixedHours = settings.upcomingEventsFixedHours
         return now + (fixedHours * Consts.HOUR_IN_MILLISECONDS)
     }
@@ -72,7 +72,7 @@ class UpcomingEventsLookahead(
      * - At 5 AM: show until 4 AM tomorrow (23 hours) - "today has begun"
      * - At 10 PM: show until 4 AM tomorrow (6 hours) - "winding down"
      */
-    private fun calculateDayBoundaryCutoff(now: Long): Long {
+    private fun calculateDayBoundaryEndTime(now: Long): Long {
         val boundaryHour = settings.upcomingEventsDayBoundaryHour
         
         val calendar = Calendar.getInstance().apply { timeInMillis = now }
@@ -95,6 +95,5 @@ class UpcomingEventsLookahead(
     companion object {
         const val MODE_FIXED = "fixed"
         const val MODE_DAY_BOUNDARY = "day_boundary"
-        const val MODE_CUTOFF = "cutoff"  // Legacy, treated as day_boundary
     }
 }

--- a/android/app/src/main/java/com/github/quarck/calnotify/upcoming/UpcomingEventsProvider.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/upcoming/UpcomingEventsProvider.kt
@@ -32,7 +32,7 @@ import com.github.quarck.calnotify.utils.CNPlusClockInterface
  * 
  * "Upcoming" events are alerts that:
  * - Have not been handled yet (wasHandled = false)
- * - Have alertTime between now and the lookahead cutoff
+ * - Have alertTime within the configured lookahead window
  * 
  * This class is designed to be testable with injected dependencies.
  */
@@ -53,12 +53,12 @@ class UpcomingEventsProvider(
      */
     fun getUpcomingEvents(): List<EventAlertRecord> {
         val now = clock.currentTimeMillis()
-        val cutoffTime = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
-        DevLog.debug(LOG_TAG, "getUpcomingEvents: now=$now, cutoff=$cutoffTime")
+        DevLog.debug(LOG_TAG, "getUpcomingEvents: now=$now, endTime=$endTime")
         
         // Fetch alerts in the time range
-        val alerts = monitorStorage.getAlertsForAlertRange(now, cutoffTime)
+        val alerts = monitorStorage.getAlertsForAlertRange(now, endTime)
             .filter { !it.wasHandled }
             .sortedBy { it.alertTime }
         

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -602,33 +602,42 @@
 
     <!-- Upcoming Events Settings -->
     <string-array name="upcoming_events_mode_entries">
-        <item>@string/upcoming_events_mode_cutoff</item>
         <item>@string/upcoming_events_mode_fixed</item>
+        <item>@string/upcoming_events_mode_day_boundary</item>
     </string-array>
 
     <string-array name="upcoming_events_mode_values">
-        <item>cutoff</item>
         <item>fixed</item>
+        <item>day_boundary</item>
     </string-array>
 
-    <string-array name="upcoming_events_cutoff_hour_entries">
+    <!-- Day boundary hour: 0 (midnight) to 10 AM, default 4 AM -->
+    <string-array name="upcoming_events_day_boundary_hour_entries">
+        <item>12 AM (midnight)</item>
+        <item>1 AM</item>
+        <item>2 AM</item>
+        <item>3 AM</item>
+        <item>4 AM</item>
+        <item>5 AM</item>
         <item>6 AM</item>
         <item>7 AM</item>
         <item>8 AM</item>
         <item>9 AM</item>
         <item>10 AM</item>
-        <item>11 AM</item>
-        <item>12 PM</item>
     </string-array>
 
-    <string-array name="upcoming_events_cutoff_hour_values">
+    <string-array name="upcoming_events_day_boundary_hour_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
         <item>6</item>
         <item>7</item>
         <item>8</item>
         <item>9</item>
         <item>10</item>
-        <item>11</item>
-        <item>12</item>
     </string-array>
 
     <string-array name="upcoming_events_fixed_hours_entries">
@@ -707,9 +716,9 @@
     <!-- Upcoming events settings -->
     <string name="upcoming_events_category">Upcoming Events</string>
     <string name="upcoming_events_mode_title">Lookahead Mode</string>
-    <string name="upcoming_events_mode_cutoff">Next morning cutoff</string>
     <string name="upcoming_events_mode_fixed">Fixed hours</string>
-    <string name="upcoming_events_cutoff_hour_title">Morning Cutoff Time</string>
+    <string name="upcoming_events_mode_day_boundary">Day boundary</string>
+    <string name="upcoming_events_day_boundary_hour_title">Day Boundary Hour</string>
     <string name="upcoming_events_fixed_hours_title">Hours to Look Ahead</string>
     <string name="navigation_settings_title">Navigation &amp; UI</string>
     <string name="use_new_navigation_ui_title">New Navigation UI</string>

--- a/android/app/src/main/res/xml/navigation_preferences.xml
+++ b/android/app/src/main/res/xml/navigation_preferences.xml
@@ -24,15 +24,15 @@
             android:dialogTitle="@string/upcoming_events_mode_title"
             android:entries="@array/upcoming_events_mode_entries"
             android:entryValues="@array/upcoming_events_mode_values"
-            android:defaultValue="cutoff" />
+            android:defaultValue="fixed" />
 
         <ListPreference
-            android:key="upcoming_events_cutoff_hour"
-            android:title="@string/upcoming_events_cutoff_hour_title"
-            android:dialogTitle="@string/upcoming_events_cutoff_hour_title"
-            android:entries="@array/upcoming_events_cutoff_hour_entries"
-            android:entryValues="@array/upcoming_events_cutoff_hour_values"
-            android:defaultValue="10" />
+            android:key="upcoming_events_day_boundary_hour"
+            android:title="@string/upcoming_events_day_boundary_hour_title"
+            android:dialogTitle="@string/upcoming_events_day_boundary_hour_title"
+            android:entries="@array/upcoming_events_day_boundary_hour_entries"
+            android:entryValues="@array/upcoming_events_day_boundary_hour_values"
+            android:defaultValue="4" />
 
         <ListPreference
             android:key="upcoming_events_fixed_hours"

--- a/android/app/src/test/java/com/github/quarck/calnotify/upcoming/UpcomingEventsLookaheadTest.kt
+++ b/android/app/src/test/java/com/github/quarck/calnotify/upcoming/UpcomingEventsLookaheadTest.kt
@@ -33,7 +33,7 @@ import org.robolectric.annotation.Config
 import java.util.Calendar
 
 /**
- * Tests for UpcomingEventsLookahead - cutoff time calculations
+ * Tests for UpcomingEventsLookahead - lookahead end time calculations
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = "AndroidManifest.xml", sdk = [24])
@@ -62,10 +62,10 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(now)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
-        val expectedCutoff = now + (8 * Consts.HOUR_IN_MILLISECONDS)
-        assertEquals("Fixed hours cutoff should be now + 8 hours", expectedCutoff, cutoff)
+        val expectedEndTime = now + (8 * Consts.HOUR_IN_MILLISECONDS)
+        assertEquals("Fixed hours should be now + 8 hours", expectedEndTime, endTime)
     }
 
     @Test
@@ -77,10 +77,10 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(now)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
-        val expectedCutoff = now + (24 * Consts.HOUR_IN_MILLISECONDS)
-        assertEquals("Fixed hours cutoff should be now + 24 hours", expectedCutoff, cutoff)
+        val expectedEndTime = now + (24 * Consts.HOUR_IN_MILLISECONDS)
+        assertEquals("Fixed hours should be now + 24 hours", expectedEndTime, endTime)
     }
 
     @Test
@@ -94,10 +94,10 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(now)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
-        val expectedCutoff = now + (8 * Consts.HOUR_IN_MILLISECONDS)
-        assertEquals("Unknown mode should default to fixed hours", expectedCutoff, cutoff)
+        val expectedEndTime = now + (8 * Consts.HOUR_IN_MILLISECONDS)
+        assertEquals("Unknown mode should default to fixed hours", expectedEndTime, endTime)
     }
 
     // === Day Boundary Mode Tests ===
@@ -117,7 +117,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: 4 AM today (3 hours ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -127,7 +127,7 @@ class UpcomingEventsLookaheadTest {
             set(Calendar.MILLISECOND, 0)
         }
         
-        assertEquals("At 1 AM with 4 AM boundary, should use 4 AM today", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 1 AM with 4 AM boundary, should use 4 AM today", expectedCalendar.timeInMillis, endTime)
     }
 
     @Test
@@ -145,7 +145,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: 4 AM tomorrow (24 hours ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -156,7 +156,7 @@ class UpcomingEventsLookaheadTest {
             add(Calendar.DAY_OF_YEAR, 1)
         }
         
-        assertEquals("At 4 AM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 4 AM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, endTime)
     }
 
     @Test
@@ -174,7 +174,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: 4 AM tomorrow (18 hours ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -185,7 +185,7 @@ class UpcomingEventsLookaheadTest {
             add(Calendar.DAY_OF_YEAR, 1)
         }
         
-        assertEquals("At 10 AM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 10 AM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, endTime)
     }
 
     @Test
@@ -203,7 +203,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: 4 AM tomorrow (6 hours ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -214,7 +214,7 @@ class UpcomingEventsLookaheadTest {
             add(Calendar.DAY_OF_YEAR, 1)
         }
         
-        assertEquals("At 10 PM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 10 PM with 4 AM boundary, should use 4 AM tomorrow", expectedCalendar.timeInMillis, endTime)
     }
 
     @Test
@@ -232,7 +232,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: Midnight tomorrow (1 hour ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -243,7 +243,7 @@ class UpcomingEventsLookaheadTest {
             add(Calendar.DAY_OF_YEAR, 1)
         }
         
-        assertEquals("At 11 PM with midnight boundary, should use midnight tomorrow", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 11 PM with midnight boundary, should use midnight tomorrow", expectedCalendar.timeInMillis, endTime)
     }
 
     @Test
@@ -261,7 +261,7 @@ class UpcomingEventsLookaheadTest {
         clock.setCurrentTime(calendar.timeInMillis)
         
         val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
+        val endTime = lookahead.getLookaheadEndTime()
         
         // Expected: 10 AM today (8 hours ahead)
         val expectedCalendar = Calendar.getInstance().apply {
@@ -271,39 +271,7 @@ class UpcomingEventsLookaheadTest {
             set(Calendar.MILLISECOND, 0)
         }
         
-        assertEquals("At 2 AM with 10 AM boundary, should use 10 AM today", expectedCalendar.timeInMillis, cutoff)
-    }
-
-    // === Legacy "cutoff" Mode Tests ===
-    // Legacy users with mode="cutoff" get day_boundary behavior with default 4am boundary
-
-    @Test
-    fun testLegacyCutoffMode_usesDayBoundaryWithDefault() {
-        // Legacy users have mode="cutoff" stored in prefs - they get day boundary with default 4am
-        settings.upcomingEventsMode = UpcomingEventsLookahead.MODE_CUTOFF
-        // Note: any old cutoff hour setting is ignored, uses new default of 4am
-        
-        // Set clock to 3 AM (before 4am boundary)
-        val calendar = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 3)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }
-        clock.setCurrentTime(calendar.timeInMillis)
-        
-        val lookahead = UpcomingEventsLookahead(settings, clock)
-        val cutoff = lookahead.getCutoffTime()
-        
-        // Expected: 4 AM today (default boundary)
-        val expectedCalendar = Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, 4)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-        }
-        
-        assertEquals("Legacy cutoff mode should use day boundary with default 4am", expectedCalendar.timeInMillis, cutoff)
+        assertEquals("At 2 AM with 10 AM boundary, should use 10 AM today", expectedCalendar.timeInMillis, endTime)
     }
 
     // === Settings Bounds Tests ===


### PR DESCRIPTION
fast follow p3 
- [x] fix lookahead ~~(the day is supposed to flip over at 12am its just suupposed to not go father than 10am following day)~~ simplified to day boundary
- [x] Banner setting getter ignores explicit user preference https://github.com/williscool/CalendarNotification/pull/175#discussion_r2692875244




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a clearer upcoming-events lookahead and aligns UI, settings, and data flow.
> 
> - Adds `day_boundary` mode (configurable 0–10) with default 4 AM and makes `fixed` mode the default; computes end time via `UpcomingEventsLookahead.getLookaheadEndTime()`
> - Updates `Settings.kt`: new keys (`upcomingEventsDayBoundaryHour`), defaults/bounds, removes legacy `newUIBannerDismissed` and simplifies `showNewUIBanner` getter
> - Refactors provider to use lookahead end time (`UpcomingEventsProvider.getUpcomingEvents()` querying `MonitorStorage.getAlertsForAlertRange(now, endTime)`) and enrich events
> - Updates preferences and strings: new entries/values, switch default mode to `fixed`, add day-boundary hour list; adjusts titles/labels
> - Adds Robolectric tests for lookahead calculations (fixed and day-boundary) and bounds
> - Updates docs to reference end-time terminology and new modes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b515050278e0f680689b3f907803253d6fb970c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->