### PR TITLE
fix: alert time on upcoming events

### DIFF
--- a/android/app/src/main/java/com/github/quarck/calnotify/ui/EventDisplayMode.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/ui/EventDisplayMode.kt
@@ -1,0 +1,33 @@
+//
+//   Calendar Notifications Plus
+//   Copyright (C) 2025 William Harris (wharris+cnplus@upscalews.com)
+//
+//   This program is free software; you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation; either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   This program is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with this program; if not, write to the Free Software Foundation,
+//   Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+//
+
+package com.github.quarck.calnotify.ui
+
+/**
+ * Display mode for event lists, determining how events are rendered.
+ * 
+ * - ACTIVE: Normal active events (shows "Snoozed until" if snoozed)
+ * - UPCOMING: Upcoming events before notification fires (shows "Alert at" for reminder time)
+ * - DISMISSED: Dismissed events (shows dismiss reason)
+ */
+enum class EventDisplayMode {
+    ACTIVE,
+    UPCOMING,
+    DISMISSED
+}

--- a/android/app/src/main/java/com/github/quarck/calnotify/ui/UpcomingEventsFragment.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/ui/UpcomingEventsFragment.kt
@@ -137,7 +137,7 @@ class UpcomingEventsFragment : Fragment(), EventListCallback, SearchableFragment
             }
             
             activity?.runOnUiThread {
-                adapter.setEventsToDisplay(events)
+                adapter.setEventsToDisplay(events, EventDisplayMode.UPCOMING)
                 updateEmptyState()
                 refreshLayout.isRefreshing = false
                 // Update search hint with new event count

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="title_activity_activity_test_buttons_and_to_do" translatable="false">ActivityTestButtonsAndToDo</string>
 
     <string name="snoozed_until_string">Snoozed until </string>
+    <string name="alert_at">Alert at %s</string>
     <string name="card_view_btn_change">CHANGE</string>
     <string name="card_view_btn_snooze">SNOOZE</string>
     <string name="settings_name">Settings</string>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a rendering mode for upcoming events and displays the next alert time in the list.
> 
> - Introduces `EventDisplayMode` (`ACTIVE`, `UPCOMING`, `DISMISSED`) to control how lists render (`EventDisplayMode.kt`)
> - Updates `EventListAdapter` to accept a `mode` and, in `UPCOMING`, show `"Alert at %s"` using `event.alertTime`; keeps existing "Snoozed until" for active snoozed events
> - `UpcomingEventsFragment` now calls `adapter.setEventsToDisplay(..., EventDisplayMode.UPCOMING)`
> - Adds `strings.xml` entry `alert_at`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e73a2db9201f7f3afbda0034cd2de6436861b8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->