### PR TITLE
ci: add test_runner_only mode for lighter integration test setup

### DIFF
--- a/.github/actions/cache-update/action.yml
+++ b/.github/actions/cache-update/action.yml
@@ -55,13 +55,17 @@ inputs:
     description: 'Whether Android SDK/AVD cache was hit (skip save if true)'
     required: false
     default: ""
+  test_runner_only:
+    description: 'Skip non-Android caches (for jobs that only run pre-built APKs)'
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
   steps:
     # JS Bundle and Assets Cache - Save only if not already cached
     - name: Save JS Bundle and Assets Cache
-      if: always() && inputs.js-bundle-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.js-bundle-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -72,7 +76,7 @@ runs:
 
     # Build Outputs Cache - Save only if not already cached
     - name: Save Build Outputs Cache
-      if: always() && inputs.arch != '' && inputs.optional_cache_key != 'integration-test' && inputs.optional_cache_key != 'unit-tests' && inputs.build-outputs-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.arch != '' && inputs.optional_cache_key != 'integration-test' && inputs.optional_cache_key != 'unit-tests' && inputs.build-outputs-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -88,7 +92,7 @@ runs:
     # Gradle dependencies cache - Save only if not already cached
     # Prevents intermittent 403s from Maven Central rate limiting in CI
     - name: Save Gradle Dependencies Cache
-      if: always() && inputs.gradle-deps-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.gradle-deps-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -98,7 +102,7 @@ runs:
 
     # Gradle cache - Save only if not already cached
     - name: Save Gradle Cache
-      if: always() && inputs.gradle-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.gradle-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
@@ -110,7 +114,7 @@ runs:
         
     # Yarn cache - Save only if not already cached
     - name: Save yarn cache
-      if: always() && inputs.yarn-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.yarn-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: $(yarn config get cacheFolder)
@@ -118,7 +122,7 @@ runs:
 
     # Yarn install state - Save only if not already cached
     - name: Save yarn install state
-      if: always() && inputs.yarn-install-state-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.yarn-install-state-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: .yarn/ci-cache/
@@ -126,7 +130,7 @@ runs:
 
     # React Native cache - Save only if not already cached
     - name: Save React Native cache
-      if: always() && inputs.react-native-cache-hit != 'true'
+      if: always() && inputs.test_runner_only != 'true' && inputs.react-native-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Skip React Native codegen (for jobs that use pre-built APKs)'
     required: false
     default: "false"
+  test_runner_only:
+    description: 'Minimal setup for running pre-built APKs on emulator (skips Node, Yarn, Gradle, JS bundle)'
+    required: false
+    default: "false"
 
 outputs:
   build-outputs-cache-hit:
@@ -99,6 +103,7 @@ runs:
 
     # Early cleanup of old Gradle caches BEFORE restoring (prevents accumulation)
     - name: Pre-cleanup old Gradle caches
+      if: inputs.test_runner_only != 'true'
       shell: bash
       run: |
         echo "Pre-cleanup: Checking for old Gradle caches..."
@@ -132,12 +137,14 @@ runs:
         df -h / | tail -1
 
     - name: Use Node.js ${{ inputs.node_version }}
+      if: inputs.test_runner_only != 'true'
       uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node_version }}
         cache: "yarn"
 
     - name: Expose yarn config as "$GITHUB_OUTPUT"
+      if: inputs.test_runner_only != 'true'
       id: yarn-config
       shell: bash
       run: |
@@ -145,6 +152,7 @@ runs:
 
     # Yarn caches
     - name: Restore yarn cache
+      if: inputs.test_runner_only != 'true'
       uses: actions/cache/restore@v4
       id: yarn-download-cache-restore
       with:
@@ -154,6 +162,7 @@ runs:
           yarn-download-cache-
 
     - name: Install dependencies
+      if: inputs.test_runner_only != 'true'
       run: yarn install --immutable --inline-builds
       shell: bash
       env:
@@ -166,6 +175,7 @@ runs:
     # This prevents "duplicate class" errors when dependencies change
     # (e.g., react-native-worklets removed since reanimated includes it)
     - name: Clean stale node_modules build artifacts
+      if: inputs.test_runner_only != 'true'
       shell: bash
       run: |
         echo "Cleaning stale native build artifacts from node_modules..."
@@ -183,6 +193,7 @@ runs:
         echo "Cleanup complete"
 
     - name: Restore yarn install state
+      if: inputs.test_runner_only != 'true'
       id: yarn-install-state-cache-restore
       uses: actions/cache/restore@v4
       with:
@@ -193,6 +204,7 @@ runs:
 
     # Cache JS Bundle and Assets
     - name: Restore JS Bundle and Assets Cache
+      if: inputs.test_runner_only != 'true'
       uses: actions/cache/restore@v4
       id: js-bundle-cache-restore
       with:
@@ -207,7 +219,7 @@ runs:
 
     # Generate JS bundle if needed
     - name: Generate JS Bundle
-      if: steps.js-bundle-cache-restore.outputs.cache-hit != 'true'
+      if: inputs.test_runner_only != 'true' && steps.js-bundle-cache-restore.outputs.cache-hit != 'true'
       run: yarn bundle:android --dev=true
       shell: bash
 
@@ -224,6 +236,7 @@ runs:
     # This uses a stable key so dependencies persist across gradle file changes
     # Prevents intermittent 403s from Maven Central rate limiting in CI
     - name: Restore Gradle Dependencies Cache
+      if: inputs.test_runner_only != 'true'
       uses: actions/cache/restore@v4
       id: gradle-deps-cache-restore
       with:
@@ -238,6 +251,7 @@ runs:
     # Cache Gradle files
     # Note: Cache key includes gradle-wrapper.properties hash to invalidate on Gradle version changes
     - name: Restore Cache Gradle files
+      if: inputs.test_runner_only != 'true'
       uses: actions/cache/restore@v4
       id: gradle-cache-restore
       with:
@@ -255,6 +269,7 @@ runs:
           ${{ runner.os }}-gradle-${{ inputs.arch != '' && format('-{0}', inputs.arch) || '' }}-
 
     - name: Setup Gradle
+      if: inputs.test_runner_only != 'true'
       uses: gradle/actions/setup-gradle@v4.0.0
       with:
         # Cache is writeable for: tag builds (to update after release) and manual dispatch from master (to refresh cache)
@@ -270,7 +285,7 @@ runs:
 
     # Restore Build Outputs Cache if arch is provided
     - name: Restore Build Outputs Cache
-      if: inputs.arch != '' && inputs.optional_cache_key != 'integration-test' && inputs.optional_cache_key != 'unit-tests'
+      if: inputs.test_runner_only != 'true' && inputs.arch != '' && inputs.optional_cache_key != 'integration-test' && inputs.optional_cache_key != 'unit-tests'
       uses: actions/cache/restore@v4
       id: build-outputs-cache-restore
       with:
@@ -288,19 +303,21 @@ runs:
           ${{ runner.os }}-build-outputs-${{ inputs.arch }}-
 
     - name: Ccachify the Native Modules
+      if: inputs.test_runner_only != 'true'
       shell: bash
       run: |
         chmod +x scripts/ccachify_native_modules.sh
         ./scripts/ccachify_native_modules.sh
 
     - name: Grant execute permission for gradlew
+      if: inputs.test_runner_only != 'true'
       run: cd android && chmod +x gradlew
       shell: bash
 
     # Run codegen for all React Native libraries (required for New Architecture)
     # Skip for jobs that use pre-built APKs (integration test shards)
     - name: Generate React Native Codegen
-      if: inputs.skip_codegen != 'true'
+      if: inputs.test_runner_only != 'true' && inputs.skip_codegen != 'true'
       run: |
         cd android && \
         ./gradlew generateCodegenSchemaFromJavaScript generateCodegenArtifactsFromSchema --parallel --max-workers=$MAX_WORKERS
@@ -308,6 +325,7 @@ runs:
 
     # Cache React Native specific files
     - name: Restore Cache React Native files
+      if: inputs.test_runner_only != 'true'
       uses: actions/cache/restore@v4
       id: react-native-cache-restore
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -711,21 +711,19 @@ jobs:
       with:
         fetch-depth: 1
 
-    # Execute the common setup with emulator configuration
-    # Skip codegen since we use pre-built APKs (saves ~3 min per shard)
+    # Execute minimal setup for running pre-built APKs on emulator
+    # Skip Node.js, Yarn, Gradle, JS bundle - only need JDK and emulator
     - name: Common Setup
       id: common-setup
       uses: ./.github/actions/common-setup
       with:
         optional_cache_key: "integration-test"
-        gradle_max_workers: "4"
-        node_version: "22.x"
         arch: ${{ matrix.arch }}
         android_api_level: ${{ env.ANDROID_API_LEVEL }}
         android_target: ${{ env.ANDROID_TARGET }}
         android_profile: ${{ env.ANDROID_PROFILE }}
         run_emulator_setup: "true"
-        skip_codegen: "true"
+        test_runner_only: "true"
 
     - name: Make scripts executable
       run: |
@@ -831,7 +829,7 @@ jobs:
         path: emulator.log
         retention-days: 90
 
-    # Update all caches (skip saves for caches that were already hit)
+    # Only save Android cache for test runners (Node/Yarn/Gradle not restored)
     - name: Update Caches
       if: always()
       uses: ./.github/actions/cache-update
@@ -840,13 +838,8 @@ jobs:
         run_emulator_setup: "true"
         android_api_level: ${{ env.ANDROID_API_LEVEL }}
         android_target: ${{ env.ANDROID_TARGET }}
-        yarn-cache-hit: ${{ steps.common-setup.outputs.yarn-cache-hit }}
-        yarn-install-state-cache-hit: ${{ steps.common-setup.outputs.yarn-install-state-cache-hit }}
-        js-bundle-cache-hit: ${{ steps.common-setup.outputs.js-bundle-cache-hit }}
-        gradle-deps-cache-hit: ${{ steps.common-setup.outputs.gradle-deps-cache-hit }}
-        gradle-cache-hit: ${{ steps.common-setup.outputs.gradle-cache-hit }}
-        react-native-cache-hit: ${{ steps.common-setup.outputs.react-native-cache-hit }}
         android-cache-hit: ${{ steps.common-setup.outputs.android-cache-hit }}
+        test_runner_only: "true"
 
     - name: Setup tmate session
       if: ${{ failure() }}


### PR DESCRIPTION
Integration test shards only need JDK + emulator to run pre-built APKs. They don't need Node.js, Yarn, Gradle caches, JS bundle, or codegen.

Changes:
- Add test_runner_only input to common-setup action
- Skip Node.js, Yarn, JS bundle, Gradle setup when test_runner_only=true
- Add test_runner_only to cache-update action to skip non-Android cache saves
- Update integration-test job to use test_runner_only: true

Estimated savings: ~1.5-2 min × 4 shards = ~6-8 min aggregate per CI run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a lightweight test-runner mode to speed up integration shards that use pre-built APKs.
> 
> - Adds `test_runner_only` input to `common-setup` and `cache-update` to bypass Node.js, Yarn install/state, JS bundle cache/generation, Gradle caches/setup, React Native caches, codegen, and related saves
> - Updates `integration-test` job to pass `test_runner_only: "true"`, keeping only JDK + Android SDK/emulator setup and limiting cache saves to Android SDK/AVD
> - Updates docs with the new mode, expected savings (~6–8 min across 4 shards), and checklist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a572849342ea51cba8369f6d58325151e5ff213. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->