### PR TITLE
ci: fix cache-warming workflow and adjust schedule

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -4,8 +4,8 @@ name: Cache Warming
 
 on:
   schedule:
-    # Run daily at 6 AM UTC (before most development activity)
-    - cron: '0 6 * * *'
+    # Run daily at 9 AM UTC (4 AM EST, before most development activity)
+    - cron: '0 9 * * *'
   push:
     branches: [master]
     paths:
@@ -46,13 +46,14 @@ jobs:
 
       # Run a minimal gradle task to populate build caches
       # This downloads dependencies and warms up the configuration cache
+      # Use architecture-specific task since this project uses per-arch build variants
       - name: Warm Gradle Caches
         run: |
           cd android && \
           ./gradlew -PBUILD_ARCH="${{ matrix.arch }}" \
                     -PreactNativeArchitectures="${{ matrix.arch }}" \
                     :app:dependencies \
-                    :app:generateDebugBuildConfig \
+                    :app:preBuild \
                     --parallel --max-workers=4 --build-cache
         env:
           BUILD_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
- Use ':app:preBuild' instead of invalid 'generateDebugBuildConfig' task (this project uses architecture-specific build variants)
- Change schedule from 6 AM UTC to 9 AM UTC (4 AM EST)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI cache warming tweaks**
> 
> - Changes schedule to run daily at `09:00 UTC` (4 AM EST)
> - Replaces invalid Gradle task `:app:generateDebugBuildConfig` with `:app:preBuild` to properly warm caches for per-arch variants
> - Adds clarifying comments about architecture-specific builds
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05b0490697ea1dc7494dfa929699eec77b52439e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->