### PR TITLE
ci: use architecture-specific task for unit test cache warming

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -82,13 +82,14 @@ jobs:
           arch: x86_64
 
       # Warm up unit test related caches
+      # Use architecture-specific task (X8664 for x86_64)
       - name: Warm Unit Test Caches
         run: |
           cd android && \
           ./gradlew -PBUILD_ARCH="x86_64" \
                     -PreactNativeArchitectures="x86_64" \
                     :app:dependencies \
-                    :app:compileDebugUnitTestKotlin \
+                    :app:compileX8664DebugUnitTestKotlin \
                     --parallel --max-workers=4 --build-cache \
                     -Pandroid.externalNativeBuild.skip=true
         env:


### PR DESCRIPTION
Use 'compileX8664DebugUnitTestKotlin' instead of 'compileDebugUnitTestKotlin' since this project uses architecture-specific build variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns unit test cache warm-up with architecture-specific build variants for x86_64.
> 
> - In `.github/workflows/cache-warming.yml`, replace `:app:compileDebugUnitTestKotlin` with `:app:compileX8664DebugUnitTestKotlin` under the "Warm Unit Test Caches" step, keeping the same gradle flags and x86_64 settings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975263e0cbf835cee4fd8c6ddc2f096697ff3a83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->