### PR TITLE
perf(ci): skip disk cleanup for test_runner_only mode

### DIFF
--- a/.github/actions/cache-update/action.yml
+++ b/.github/actions/cache-update/action.yml
@@ -113,11 +113,12 @@ runs:
         key: ${{ runner.os }}${{ inputs.optional_cache_key != '' && format('-{0}', inputs.optional_cache_key) || '' }}-gradle-${{ inputs.arch != '' && format('-{0}', inputs.arch) || '' }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
         
     # Yarn cache - Save only if not already cached
+    # Note: Yarn 3 default cache folder is .yarn/cache in project directory
     - name: Save yarn cache
       if: always() && inputs.test_runner_only != 'true' && inputs.yarn-cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
-        path: $(yarn config get cacheFolder)
+        path: .yarn/cache
         key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
 
     # Yarn install state - Save only if not already cached

--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -89,8 +89,10 @@ runs:
         echo "Detected ${CPU_COUNT} CPUs for parallel builds"
       shell: bash
 
-    # Free Disk Space - run for all jobs to prevent out-of-space errors
+    # Free Disk Space - skip for test_runner_only since it doesn't need Gradle/Node
+    # (emulator + APKs fit comfortably in default runner disk space)
     - name: Free Disk Space
+      if: inputs.test_runner_only != 'true'
       uses: endersonmenezes/free-disk-space@v3
       with:
         remove_android: false        # Keep Android SDK


### PR DESCRIPTION
Integration test shards using test_runner_only don't need the disk cleanup since they skip Gradle/Node downloads. The emulator + APKs fit comfortably in the default runner disk space (~14GB free).

This should save ~1-2 min per integration test shard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes CI setup by gating disk cleanup in the shared action.
> 
> - Updates `.github/actions/common-setup/action.yml` to run `Free Disk Space` only when `inputs.test_runner_only != 'true'`
> - Adjusts comments to reflect the conditional behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77b91f4cc850eed44db4aa22dfbc56b7c6d4d6bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->