### PR TITLE
perf(ci): add ccache to cache-warming workflow

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -37,6 +37,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      # ccache for native compilation - critical for fast builds
+      # This creates a cache entry on master that PR branches can restore from
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+
       - name: Common Setup
         uses: ./.github/actions/common-setup
         with:
@@ -44,16 +51,14 @@ jobs:
           node_version: "22.x"
           arch: ${{ matrix.arch }}
 
-      # Run a minimal gradle task to populate build caches
-      # This downloads dependencies and warms up the configuration cache
-      # Use architecture-specific task since this project uses per-arch build variants
-      - name: Warm Gradle Caches
+      # Build debug APK to populate ccache with compiled native code
+      # This is slower than minimal tasks but makes PR builds much faster
+      - name: Warm Gradle and Native Caches
         run: |
           cd android && \
           ./gradlew -PBUILD_ARCH="${{ matrix.arch }}" \
                     -PreactNativeArchitectures="${{ matrix.arch }}" \
-                    :app:dependencies \
-                    :app:preBuild \
+                    :app:assemble${{ matrix.arch == 'arm64-v8a' && 'Arm64V8a' || 'X8664' }}Debug \
                     --parallel --max-workers=4 --build-cache
         env:
           BUILD_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
The ccache stores compiled native code (React Native modules, NDK). Without a warm ccache, builds need to recompile ~600 C/C++ files.

Analysis of run 21099329972 showed:
- With ccache: build step takes 153s (2.5 min)
- Without ccache: build step takes 1110s (18.5 min)

Changes:
- Add ccache action to warm-build-caches job
- Build debug APK (not just dependencies) to populate ccache
- This makes cache-warming slower but makes PR builds much faster

The ccache saves with timestamp key on master, and PR branches restore using prefix matching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up PR builds by pre-populating native compilation cache during scheduled cache warming.
> 
> - Add `hendrikmuhs/ccache-action@v1.2` with `create-symlink` to `warm-build-caches` job
> - Replace minimal Gradle tasks with per-arch `:app:assemble{Arm64V8a|X8664}Debug` to populate ccache for native code
> - Retain cache save step; other jobs unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7717627637b8f99d257b4a7c4c9d0d650218d34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->