### PR TITLE
ci(perf): add ccache to cache-warming with full build coverage

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -51,14 +51,17 @@ jobs:
           node_version: "22.x"
           arch: ${{ matrix.arch }}
 
-      # Build debug APK to populate ccache with compiled native code
-      # This is slower than minimal tasks but makes PR builds much faster
+      # Build debug, release, and test APKs to fully populate ccache
+      # Regular builds compile ~596 native files (debug + release + test)
+      # This is slower but makes PR builds much faster
       - name: Warm Gradle and Native Caches
         run: |
           cd android && \
           ./gradlew -PBUILD_ARCH="${{ matrix.arch }}" \
                     -PreactNativeArchitectures="${{ matrix.arch }}" \
                     :app:assemble${{ matrix.arch == 'arm64-v8a' && 'Arm64V8a' || 'X8664' }}Debug \
+                    :app:assemble${{ matrix.arch == 'arm64-v8a' && 'Arm64V8a' || 'X8664' }}Release \
+                    :app:assemble${{ matrix.arch == 'arm64-v8a' && 'Arm64V8a' || 'X8664' }}DebugAndroidTest \
                     --parallel --max-workers=4 --build-cache
         env:
           BUILD_ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
The ccache stores compiled native code (React Native modules, NDK). Without a warm ccache, builds need to recompile ~600 C/C++ files.

Analysis showed cache warming was only compiling 298 files (debug only), but regular builds compile 596 files (debug + release + test).

Changes:
- Add ccache action to warm-build-caches job
- Build debug, release, AND test APKs to fully populate ccache
- This matches what the regular build jobs compile

Expected result: PR builds should get 100% ccache hits instead of ~50%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens CI cache warming to maximize cache hits for Android builds.
> 
> - Add `hendrikmuhs/ccache-action` (with symlink) to persist native compilation artifacts
> - Replace minimal Gradle warm-up with assembling `Debug`, `Release`, and `DebugAndroidTest` APKs for `arm64-v8a` and `x86_64`
> - Retain explicit cache save via `cache-update`; no code changes outside `cache-warming.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d3de07a3e87ba8d7c15656b4a47fc158c558e88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->