### PR TITLE
ci(perf): optimize merge-integration-coverage job

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: 'Minimal setup for running pre-built APKs on emulator (skips Node, Yarn, Gradle, JS bundle)'
     required: false
     default: "false"
+  skip_disk_space:
+    description: 'Skip free disk space cleanup (for jobs that dont need extra space)'
+    required: false
+    default: "false"
 
 outputs:
   build-outputs-cache-hit:
@@ -89,10 +93,10 @@ runs:
         echo "Detected ${CPU_COUNT} CPUs for parallel builds"
       shell: bash
 
-    # Free Disk Space - skip for test_runner_only since it doesn't need Gradle/Node
-    # (emulator + APKs fit comfortably in default runner disk space)
+    # Free Disk Space - skip for test_runner_only or skip_disk_space
+    # (emulator + APKs, or coverage merge jobs fit comfortably in default runner disk space)
     - name: Free Disk Space
-      if: inputs.test_runner_only != 'true'
+      if: inputs.test_runner_only != 'true' && inputs.skip_disk_space != 'true'
       uses: endersonmenezes/free-disk-space@v3
       with:
         remove_android: false        # Keep Android SDK

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -899,6 +899,7 @@ jobs:
           echo "=== Merged coverage files ==="
           find android/app/build/outputs/code_coverage/ -name "*.ec" -ls 2>/dev/null || echo "No .ec files found"
 
+      # Skip codegen and disk cleanup - this job only runs JaCoCo report generation
       - name: Common Setup
         uses: ./.github/actions/common-setup
         with:
@@ -906,6 +907,8 @@ jobs:
           gradle_max_workers: "4"
           node_version: "22.x"
           arch: x86_64
+          skip_codegen: "true"
+          skip_disk_space: "true"
 
       - name: Generate Merged JaCoCo Report
         run: |


### PR DESCRIPTION
Add skip_disk_space input to common-setup for jobs that don't need extra disk space (like coverage merge which only downloads artifacts and runs JaCoCo).

Changes to merge-integration-coverage:
- skip_codegen: true - not building anything
- skip_disk_space: true - downloads + JaCoCo fit in default space

Expected savings: ~2-3 min (disk cleanup + codegen)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes the coverage merge workflow by avoiding unnecessary setup.
> 
> - Adds `skip_disk_space` input to `./.github/actions/common-setup` and updates the Free Disk Space step condition to also check this flag
> - In `merge-integration-coverage` job, sets `skip_codegen: "true"` and `skip_disk_space: "true"` since it only generates JaCoCo reports from downloaded artifacts
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a74c9b1fa79bfe3b880a0d31e405ae9afe17037b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->