### PR TITLE
test: Temporarily ignore flaky search_partial_match_works test

### DIFF
--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityModernTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityModernTest.kt
@@ -22,6 +22,7 @@ import io.mockk.*
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -680,6 +681,7 @@ class MainActivityModernTest : BaseUltronTest() {
     }
     
     @Test
+    @Ignore("Flaky test - temporarily disabled")
     fun search_partial_match_works() {
         fixture.createEvent(title = "Important Meeting")
         fixture.createEvent(title = "Unimportant Task")


### PR DESCRIPTION
Co-authored-by: wharris <wharris@upscalews.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily skip a flaky UI test to stabilize CI.
> 
> - Adds `@Ignore("Flaky test - temporarily disabled")` to `search_partial_match_works` in `android/app/src/androidTest/java/com/github/quarck/calnotify/ui/MainActivityModernTest.kt`
> - Imports `org.junit.Ignore` to support the annotation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b114376faefbbfeacaaceb6fd09f35ab1b7b57d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->