### PR TITLE
perf(ci): skip disk cleanup and codegen for unit tests

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -395,7 +395,8 @@ jobs:
         create-symlink: true
 
     # Execute the common setup
-    # Skip disk cleanup and codegen - unit tests are pure Kotlin/Java, don't use emulator
+    # Skip disk cleanup - unit tests are pure Kotlin/Java, don't use emulator
+    # Note: codegen IS needed because native modules depend on generated React Native specs
     - name: Common Setup
       uses: ./.github/actions/common-setup
       with:
@@ -404,7 +405,6 @@ jobs:
         node_version: "22.x"
         arch: ${{ matrix.arch }}
         skip_disk_space: "true"
-        skip_codegen: "true"
 
     # Run Jest tests (TypeScript/JavaScript unit tests) with coverage
     - name: Run Jest Tests


### PR DESCRIPTION
Unit tests are pure Kotlin/Java Robolectric tests - they don't:
- Use emulator (no extra disk space needed)
- Use React Native codegen output (no RN references in tests)

Already skips native builds with -Pandroid.externalNativeBuild.skip=true

Expected savings: ~3-4 min in Common Setup (disk cleanup + codegen)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up CI by avoiding unnecessary setup in jobs that don't require emulator or RN artifacts.
> 
> - Unit tests: `Common Setup` now sets `skip_disk_space: "true"` and `skip_codegen: "true"`
> - Merge integration coverage: `Common Setup` also sets `skip_disk_space: "true"` and `skip_codegen: "true"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be3c4b2ac513e951f29ae9bb7f25c7e55ea2131. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->