### PR TITLE
ci: Cursor/unit tests codegen cache

### DIFF
--- a/.github/workflows/cache-warming.yml
+++ b/.github/workflows/cache-warming.yml
@@ -22,6 +22,11 @@ on:
 env:
   # Reuse settings from main workflow
   GRADLE_OPTS: "-Dorg.gradle.daemon=true -Dorg.gradle.workers.max=4 -Dorg.gradle.parallel=true -Dorg.gradle.caching=true"
+  # ccache settings must match main workflow for cache hits
+  CCACHE_DEBUG: 1
+  CCACHE_VERBOSE: 1
+  CCACHE_MAXSIZE: 5G
+  CCACHE_BASEDIR: ${{ github.workspace }}
 
 jobs:
   warm-build-caches:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves CI caching correctness and alignment across workflows.
> 
> - Include `yarn.lock` in Android build outputs cache keys in `common-setup` and `cache-update` to invalidate when JS deps change (impacts React Native codegen)
> - Clarify that unit tests restore but do not save build outputs and that codegen cannot be skipped due to Gradle task graph
> - Align `cache-warming` workflow with main CI by defining matching `CCACHE_*` environment variables
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce19fd1b4f7549895767289d54148c363192dd85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->