### PR TITLE
docs: gh pr comments rule

### DIFF
--- a/.cursor/rules/gh-pr-comments.mdc
+++ b/.cursor/rules/gh-pr-comments.mdc
@@ -1,0 +1,49 @@
+# .cursor/rules/gh-pr-comments.mdc
+---
+alwaysApply: false
+---
+# GitHub CLI - Pull Request Comments & Review Context
+
+This project uses GitHub CLI to fetch and analyze pull request review comments with detailed context.
+
+## Getting Review Comments with Line Numbers & Resolution Status
+
+### Primary Command (GraphQL - Full Featured)
+
+Use GraphQL API to get complete comment context including resolution status and line numbers:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            isResolved
+            isOutdated
+            comments(first: 20) {
+              nodes {
+                author {
+                  login
+                }
+                body
+                path
+                line
+                startLine
+                originalLine
+                originalStartLine
+                diffHunk
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=OWNER -f repo=REPO -F prNumber=PR_NUMBER


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces documentation in `.cursor/rules/gh-pr-comments.mdc` for retrieving PR review comments with full context via GitHub CLI.
> 
> - Adds a GraphQL-based `gh api` command example to fetch review threads, including resolution status, outdated state, file path, line ranges, diff hunks, and timestamps
> - Clarifies usage with pagination variables (`cursor`) and required parameters (`owner`, `repo`, `prNumber`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6afaf23a57109adae9db1b0be927b121ff1825d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->