### PR TITLE
test: cursor calendar provider clock fix

### DIFF
--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/testutils/CalendarProviderTestFixture.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/testutils/CalendarProviderTestFixture.kt
@@ -29,6 +29,9 @@ class CalendarProviderTestFixture {
     }
     
     private fun setupInitialState() {
+        // Inject test clock into CalendarProvider for deterministic time behavior
+        CalendarProvider.clockProvider = { timeProvider.testClock }
+        
         // Clear any existing settings that might affect calendar handling
         val settings = Settings(contextProvider.fakeContext)
         settings.setBoolean("enable_manual_calendar_rescan", false)
@@ -324,6 +327,9 @@ class CalendarProviderTestFixture {
      * Cleans up test resources
      */
     fun cleanup() {
+        // Reset CalendarProvider clock to prevent test pollution
+        CalendarProvider.resetClockProvider()
+        
         baseFixture.cleanup()
     }
 

--- a/android/app/src/main/java/com/github/quarck/calnotify/calendar/CalendarProvider.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/calendar/CalendarProvider.kt
@@ -41,9 +41,22 @@ object CalendarProvider : CalendarProviderInterface {
     private const val LOG_TAG = "CalendarProvider"
 
     /**
-     * Clock implementation for time operations
+     * Provider for Clock - enables DI for testing
      */
-    override val clock: CNPlusClockInterface = CNPlusSystemClock()
+    var clockProvider: (() -> CNPlusClockInterface)? = null
+    
+    /**
+     * Clock implementation for time operations - uses clockProvider if set, otherwise real clock
+     */
+    override val clock: CNPlusClockInterface
+        get() = clockProvider?.invoke() ?: CNPlusSystemClock()
+    
+    /**
+     * Reset clock provider - call in @After to prevent test pollution
+     */
+    fun resetClockProvider() {
+        clockProvider = null
+    }
 
     private val alertFields =
             arrayOf(


### PR DESCRIPTION
CalendarProviderReminderTest was failing because:
- CalendarProvider.getNextEventReminderTime() filters reminders using clock.currentTimeMillis()
- With test time changed to December 2023 (past) and real time being January 2026
- All reminders were filtered out as 'in the past', returning 0

Added clockProvider pattern to CalendarProvider (same as ApplicationController) and inject test clock via CalendarProviderTestFixture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures deterministic time-dependent behavior and fixes reminder filtering issues caused by mismatch between real and test time.
> 
> - Add `clockProvider` DI hook and computed `clock` in `CalendarProvider`; introduce `resetClockProvider()` to clear overrides
> - Update `CalendarProviderTestFixture` to set `CalendarProvider.clockProvider` to test clock during setup and reset it in `cleanup()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f262e2f68ed4687b02f24d034b82f478a788c898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->