### PR TITLE
test: inject testClock into CalendarProvider in CalendarMonitorService…

### DIFF
--- a/android/app/src/androidTest/java/com/github/quarck/calnotify/deprecated_raw_calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
+++ b/android/app/src/androidTest/java/com/github/quarck/calnotify/deprecated_raw_calendarmonitor/CalendarMonitorServiceEventReminderTest.kt
@@ -136,8 +136,9 @@ class CalendarMonitorServiceEventReminderTest {
   fun cleanup() {
     DevLog.info(LOG_TAG, "Cleaning up test environment")
     
-    // Reset the clock provider before unmocking to avoid test pollution
+    // Reset the clock providers before unmocking to avoid test pollution
     ApplicationController.resetClockProvider()
+    CalendarProvider.resetClockProvider()
     
     unmockkAll()
 
@@ -630,8 +631,9 @@ class CalendarMonitorServiceEventReminderTest {
     testClock = CNPlusTestClock(TestTimeConstants.STANDARD_TEST_TIME, mockTimer)
     currentTime.set(testClock.currentTimeMillis())
     
-    // Inject testClock into ApplicationController so time-dependent operations use the same clock
+    // Inject testClock into ApplicationController and CalendarProvider so time-dependent operations use the same clock
     ApplicationController.clockProvider = { testClock }
+    CalendarProvider.clockProvider = { testClock }
     
     // No need to manually configure mockTimer's schedule behavior anymore
     // as this is now handled by CNPlusTestClock's init block


### PR DESCRIPTION
…EventReminderTest

testCalendarMonitoringDirectReminder was failing because CalendarProvider wasn't using the test clock, causing time-dependent operations to fail.

Added CalendarProvider.clockProvider injection in setupMockTimer() and reset in cleanup() to match the pattern used for ApplicationController.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns test time sources to prevent flaky, time-dependent failures in `CalendarMonitorServiceEventReminderTest`.
> 
> - Injects `testClock` into `CalendarProvider` via `CalendarProvider.clockProvider` in `setupMockTimer()` so provider logic uses the same clock as `ApplicationController`
> - Resets both `ApplicationController` and `CalendarProvider` clock providers in `cleanup()` to avoid cross-test pollution
> - Minor comment clarifications; no production code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c9aab1b06ca3cc6842ba02a2bcf0407b1f8a6e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->