### PR TITLE
refactor: Extract event key Intent format to single source of truth

### DIFF
--- a/android/app/src/main/java/com/github/quarck/calnotify/app/ApplicationController.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/app/ApplicationController.kt
@@ -976,17 +976,10 @@ object ApplicationController : ApplicationControllerInterface, EventMovedHandler
     ): SnoozeResult? {
         if (eventKeys.isEmpty()) return null
         
-        // Parse event keys into (eventId, instanceStartTime) pairs
-        val keyPairs = eventKeys.mapNotNull { key ->
-            val parts = key.split(":")
-            if (parts.size == 2) {
-                val eventId = parts[0].toLongOrNull()
-                val instanceStartTime = parts[1].toLongOrNull()
-                if (eventId != null && instanceStartTime != null) {
-                    Pair(eventId, instanceStartTime)
-                } else null
-            } else null
-        }.toSet()
+        // Parse event keys into (eventId, instanceStartTime) pairs using the shared format
+        val keyPairs = eventKeys.mapNotNull { EventAlertRecordKey.fromIntentString(it) }
+            .map { Pair(it.eventId, it.instanceStartTime) }
+            .toSet()
         
         return snoozeEvents(context, { event ->
             keyPairs.contains(Pair(event.eventId, event.instanceStartTime))

--- a/android/app/src/main/java/com/github/quarck/calnotify/calendar/EventAlertRecord.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/calendar/EventAlertRecord.kt
@@ -110,7 +110,22 @@ fun Long.setFlag(flag: Long, value: Boolean)
         else
             this and flag.inv()
 
-data class EventAlertRecordKey(val eventId: Long, val instanceStartTime: Long)
+data class EventAlertRecordKey(val eventId: Long, val instanceStartTime: Long) {
+    
+    /** Serialize for Intent extras */
+    fun toIntentString(): String = "$eventId:$instanceStartTime"
+    
+    companion object {
+        /** Parse from Intent extras */
+        fun fromIntentString(key: String): EventAlertRecordKey? {
+            val parts = key.split(":")
+            if (parts.size != 2) return null
+            val eventId = parts[0].toLongOrNull() ?: return null
+            val instanceStartTime = parts[1].toLongOrNull() ?: return null
+            return EventAlertRecordKey(eventId, instanceStartTime)
+        }
+    }
+}
 
 data class EventAlertRecord(
         val calendarId: Long,

--- a/android/app/src/main/java/com/github/quarck/calnotify/ui/ActiveEventsFragment.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/ui/ActiveEventsFragment.kt
@@ -182,7 +182,7 @@ class ActiveEventsFragment : Fragment(), EventListCallback, SearchableFragment, 
         val isChange = !hasActiveEvents
         
         // Pass selected event keys to SnoozeAllActivity via intent
-        val eventKeys = selectedEvents.map { "${it.eventId}:${it.instanceStartTime}" }.toTypedArray()
+        val eventKeys = selectedEvents.map { it.key.toIntentString() }.toTypedArray()
         
         // Get filter/search context for display
         val filterState = getFilterState()


### PR DESCRIPTION
Added toIntentString() and fromIntentString() methods to EventAlertRecordKey class to ensure the event key format used in Intent extras is defined in one place. This prevents format mismatches between serialization and parsing.

- EventAlertRecordKey.toIntentString(): Serializes key for Intent extras
- EventAlertRecordKey.fromIntentString(): Parses key from Intent extras
- Updated ActiveEventsFragment to use toIntentString()
- Updated ApplicationController to use fromIntentString()

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies the event key format used in Intent extras by making `EventAlertRecordKey` the single source of truth.
> 
> - Adds `toIntentString()` and `fromIntentString()` to `EventAlertRecordKey` for Intent serialization/parsing
> - Replaces manual string building in `ActiveEventsFragment` with `it.key.toIntentString()` when launching `SnoozeAllActivity`
> - Replaces ad-hoc parsing in `ApplicationController.snoozeSelectedEvents` with `EventAlertRecordKey.fromIntentString()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 055c4408525665dbab109d3848cf278733e77257. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->