### PR TITLE
ci: tmate configuration

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -41,6 +41,11 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      enable_tmate:
+        description: 'Enable tmate SSH session on failure'
+        type: boolean
+        default: false
 
 jobs:
   set_build_datetime:
@@ -135,7 +140,7 @@ jobs:
         BUILD_ARCH: ${{ matrix.arch }}
 
     - name: Setup tmate session
-      if: ${{ failure() }}
+      if: ${{ failure() && inputs.enable_tmate == true }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
@@ -583,7 +588,7 @@ jobs:
         retention-days: 90
 
     - name: Setup tmate session
-      if: ${{ failure() }}
+      if: ${{ failure() && inputs.enable_tmate == true }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true
@@ -855,7 +860,7 @@ jobs:
         test_runner_only: "true"
 
     - name: Setup tmate session
-      if: ${{ failure() }}
+      if: ${{ failure() && inputs.enable_tmate == true }}
       uses: mxschmitt/action-tmate@v3
       with:
         limit-access-to-actor: true


### PR DESCRIPTION
Make tmate opt-in for the main CI workflow (`actions.yml`) to reduce noise during normal runs, while keeping it available for manual debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbf04972-3f21-421d-9e03-bc73aff42aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bbf04972-3f21-421d-9e03-bc73aff42aaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes tmate debugging opt-in for the main CI workflow.
> 
> - Adds `workflow_dispatch.inputs.enable_tmate` (boolean, default `false`)
> - Updates tmate steps in `build`, `verify-connected-android-test-working-single-integration-test`, and `integration-test` to run only when `failure() && inputs.enable_tmate == true`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf64a043fefd807e159e77632cabf4ece204e27f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->