### PR TITLE
ci: Pr build latest commit

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -317,9 +317,6 @@ jobs:
             SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
             SUFFIX="-${BRANCH_NAME}-${SHORT_SHA}"
           fi
-        env:
-          # For PRs, this is the actual PR head commit; for other events it's empty (not used)
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
           # Find and rename signed debug APKs
           find signing/apk/debug/ -name "*-signed.apk" | while read apk; do
@@ -339,6 +336,9 @@ jobs:
           # List all renamed files
           echo "Renamed files:"
           ls -la renamed_apks/
+        env:
+          # For PRs, this is the actual PR head commit; for other events it's empty (not used)
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       # Upload signed artifacts
       - name: Upload SIGNED APK Debug


### PR DESCRIPTION
Update GitHub Actions to build pull requests against the actual branch head commit, ensuring accurate commit SHAs in comments and artifact names.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ec0ee46-3330-4dde-8563-11fd8c3882fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ec0ee46-3330-4dde-8563-11fd8c3882fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures CI runs against the actual PR head commit and surfaces the correct SHA in outputs.
> 
> - Use `ref: ${{ github.event.pull_request.head.sha || github.sha }}` in `actions/checkout` across jobs (`safety_checks`, `build`, `sign`, `unit-tests`, `integration-test`, `merge-integration-coverage`, `coverage-report`, `create-release`)
> - Artifact renaming in `sign` now uses `PR_HEAD_SHA` for PRs; adds `env PR_HEAD_SHA` for accurate short SHA in file suffixes
> - PR comment updated to link and display the short head commit SHA instead of the merge SHA
> - No app code changes; CI-only adjustments for build, signing, and reporting consistency
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80b049360a19f50c2e825ac6bd2f305c448542b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->