### PR TITLE
feat: display git commit SHA on About page

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,6 +99,9 @@ android {
     versionName "9.16.0"
 
     buildConfigField "long", "TIMESTAMP", System.currentTimeMillis() + "L"
+    // Git commit SHA for identifying builds
+    def gitSha = 'git rev-parse --short HEAD'.execute().text.trim()
+    buildConfigField "String", "GIT_COMMIT_SHA", "\"${gitSha}\""
     // React Native New Architecture flags
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", project.hasProperty("newArchEnabled") ? project.property("newArchEnabled") : "false"
     buildConfigField "boolean", "IS_HERMES_ENABLED", project.hasProperty("hermesEnabled") ? project.property("hermesEnabled") : "true"

--- a/android/app/src/main/java/com/github/quarck/calnotify/ui/AboutActivity.kt
+++ b/android/app/src/main/java/com/github/quarck/calnotify/ui/AboutActivity.kt
@@ -51,6 +51,9 @@ class AboutActivity : AppCompatActivity() {
 
         val buildTime = find<TextView?>(R.id.text_view_app_build_time)
         buildTime?.text = String.format(resources.getString(R.string.build_time_string_format), getBuildDate())
+
+        val commitSha = find<TextView?>(R.id.text_view_app_commit_sha)
+        commitSha?.text = String.format(resources.getString(R.string.commit_sha_string_format), BuildConfig.GIT_COMMIT_SHA)
     }
 
     fun getBuildDate(): String {

--- a/android/app/src/main/res/layout/content_about.xml
+++ b/android/app/src/main/res/layout/content_about.xml
@@ -49,6 +49,16 @@
             android:layout_gravity="center_horizontal"
             tools:ignore="HardcodedText"
             />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/text_view_app_commit_sha"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@color/primary_text"
+            android:text="commit"
+            android:layout_gravity="center_horizontal"
+            tools:ignore="HardcodedText"
+            />
 
         <TextView
             android:layout_width="wrap_content"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -239,6 +239,7 @@
     <string name="use_set_alarm_clock_summary">Marshmallow and above only!\nThis would trigger app to use setAlarmClock API call when scheduling reminders and snoozed events\nThis would increase reminders time accuracy\nAs a side effect, user would see \'alarm\' icon on UI when there are snoozed events or active reminders</string>
 
     <string name="build_time_string_format" formatted="false">Build time: %s</string>
+    <string name="commit_sha_string_format" formatted="false">Commit: %s</string>
     <string name="dismiss_all_events">Dismiss all events</string>
     <string name="dismiss_all_events_confirmation">Dismiss all events?\n\nCANNOT BE UNDONE!\n\nSnoozed events would not be removed</string>
     <string name="handle_events_with_no_reminders">Handle events with no reminders</string>


### PR DESCRIPTION
- Add GIT_COMMIT_SHA buildConfigField in build.gradle using git rev-parse
- Add TextView to content_about.xml to display commit SHA below build time
- Update AboutActivity.kt to populate the commit SHA from BuildConfig
- Add commit_sha_string_format string resource

This helps identify exactly which commit a build came from when looking at the About page in the app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds commit identification to the About screen.
> 
> - In `build.gradle`, generate `BuildConfig.GIT_COMMIT_SHA` from `git rev-parse --short HEAD`
> - Update `AboutActivity.kt` to read `BuildConfig.GIT_COMMIT_SHA` and set it on `text_view_app_commit_sha`
> - Add `TextView` in `content_about.xml` for commit SHA display
> - Add `commit_sha_string_format` in `strings.xml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46dc476d296b4e027a18a95bac8def650a1215de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->