### PR TITLE
fix: bottom sheet styles simple

### DIFF
--- a/android/app/src/main/res/values-night/styles.xml
+++ b/android/app/src/main/res/values-night/styles.xml
@@ -4,5 +4,10 @@
     <!-- Use dark popup overlay in dark mode -->
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Dark"></style>
     
+    <!-- Bottom sheet dark mode - uses dark cardview background (#1E1E1E) -->
+    <style name="AppTheme.BottomSheet" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="backgroundTint">@color/cardview_light_background</item>
+    </style>
+    
 </resources>
 

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -10,6 +10,8 @@
         <item name="android:colorBackground">@color/background</item>
         <!-- Preference list styling -->
         <item name="android:listViewStyle">@style/AppListView</item>
+        <!-- Bottom sheet dialog theme for proper theming -->
+        <item name="bottomSheetDialogTheme">@style/AppTheme.BottomSheetDialog</item>
     </style>
     
     <style name="AppListView" parent="Widget.AppCompat.ListView">
@@ -24,6 +26,15 @@
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"></style>
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"></style>
+
+    <!-- Bottom sheet dialog theme - uses cardview background for consistency -->
+    <style name="AppTheme.BottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/AppTheme.BottomSheet</item>
+    </style>
+
+    <style name="AppTheme.BottomSheet" parent="Widget.MaterialComponents.BottomSheet.Modal">
+        <item name="backgroundTint">@color/cardview_light_background</item>
+    </style>
 
     <style name="PickerDialogTheme" parent="AppTheme.NoActionBar">
         <item name="android:textSize">20sp</item>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures consistent theming for Material BottomSheets across light and dark modes.
> 
> - Adds `AppTheme.BottomSheet` (Modal) with `backgroundTint` set to `@color/cardview_light_background`
> - Introduces `AppTheme.BottomSheetDialog` and wires it via `bottomSheetDialogTheme` in `AppTheme`
> - Provides a night-mode override for `AppTheme.BottomSheet`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 244a4215c11d6186e794129c731421a88a73fd94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->