### PR TITLE
fix: activity_view title overflow

### DIFF
--- a/android/app/src/main/res/layout/activity_view.xml
+++ b/android/app/src/main/res/layout/activity_view.xml
@@ -60,6 +60,7 @@
                     android:minLines="2"
                     android:id="@+id/snooze_view_title"
                     android:layout_below="@id/status_bar_spacer"
+                    android:layout_toStartOf="@id/snooze_view_menu"
                     android:text="Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. Event Title Place Holder. "
                     android:textAppearance="?android:textAppearanceMedium"
                     android:textSize="19sp"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the header title in `activity_view.xml` does not overlap the menu icon.
> 
> - Add `android:layout_toStartOf="@id/snooze_view_menu"` to `snooze_view_title` in `activity_view.xml` to constrain the title within available space
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5e9791e653c8c64a58681328a5cfc35a1125291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->