### PR TITLE
docs: skill_instruction_update_2026_02_23

### DIFF
--- a/.cursor/skills/github-pr-comments/SKILL.md
+++ b/.cursor/skills/github-pr-comments/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: github-pr-comments
+description: Helps the agent fetch and interpret GitHub CLI / GraphQL queries for pull request review comments with line numbers and resolution status.
+---
+
+# GitHub PR review comments skill
+
+This skill guides the agent to use GitHub CLI and GraphQL to fetch pull request review comments with detailed context including line numbers and resolution status.
+
+## When to use
+
+- When the goal is to examine PR review threads, comments, and their status (resolved/outdated).
+- When you need to analyze or summarize PR feedback tied to specific files/lines.
+- When building tools or scripts that process GitHub PR comments programmatically.
+
+## Instructions
+
+1. Prefer the GitHub CLI GraphQL query shown below to get full review‑thread context, including resolution status and line numbers.  
+2. Substitute `OWNER`, `REPO`, and `PR_NUMBER` with the correct values before running.
+3. If the response is paginated, use `endCursor` from `pageInfo` to iterate the next page until `hasNextPage` is `false`.
+
+### Primary command (GraphQL – full‑featured)
+
+Run this command in the terminal to fetch review threads with comments, paths, line numbers, and resolution status:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            isResolved
+            isOutdated
+            comments(first: 20) {
+              nodes {
+                author {
+                  login
+                }
+                body
+                path
+                line
+                startLine
+                originalLine
+                originalStartLine
+                diffHunk
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=OWNER -f repo=REPO -F prNumber=PR_NUMBER
+---
+name: github-pr-comments
+description: Helps the agent fetch and interpret GitHub CLI / GraphQL queries for pull request review comments with line numbers and resolution status.
+---
+
+# GitHub PR review comments skill
+
+This skill guides the agent to use GitHub CLI and GraphQL to fetch pull request review comments with detailed context including line numbers and resolution status.
+
+## When to use
+
+- When the goal is to examine PR review threads, comments, and their status (resolved/outdated).
+- When you need to analyze or summarize PR feedback tied to specific files/lines.
+- When building tools or scripts that process GitHub PR comments programmatically.
+
+## Instructions
+
+1. Prefer the GitHub CLI GraphQL query shown below to get full review‑thread context, including resolution status and line numbers.  
+2. Substitute `OWNER`, `REPO`, and `PR_NUMBER` with the correct values before running.
+3. If the response is paginated, use `endCursor` from `pageInfo` to iterate the next page until `hasNextPage` is `false`.
+
+### Primary command (GraphQL – full‑featured)
+
+Run this command in the terminal to fetch review threads with comments, paths, line numbers, and resolution status:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $prNumber: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        reviewThreads(first: 100, after: $cursor) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          nodes {
+            isResolved
+            isOutdated
+            comments(first: 20) {
+              nodes {
+                author {
+                  login
+                }
+                body
+                path
+                line
+                startLine
+                originalLine
+                originalStartLine
+                diffHunk
+                createdAt
+                updatedAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' -f owner=OWNER -f repo=REPO -F prNumber=PR_NUMBER

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,17 @@
-# Dont change any non test code without getting confirmation first
 
-Dont change any non test code without getting confirmation first. this is a very old application I'm working on making a thorough test suite for before making any changes
+# Code Changes
 
+This is a legacy codebase (2016) with a robust test suite added in 2024-25.
+
+**Permitted without confirmation:**
+- Bug fixes with corresponding test coverage
+- Refactoring with existing test coverage
+- Removal of deprecated features (QuietHours, CalendarEditor)
+
+**Requires tests first:**
+- New features or significant changes
+
+When in doubt, add tests first.
 
 # Work to make tests as faithful to the real code as possible
 
@@ -10,24 +20,47 @@ its ok to mock out core android apis that the instrumentation testsuite doesn't 
 
 # Don't try to boil the ocean. Dont try to make big sweeping changes when more focused ones will do
 
-Always think of the minimum viable solution to a problem or change to make. make sure that works and then build on top of it. break things down into small testable pieces first. That said NO CHEATING! I.e. don't comment out or skip a test to solve a problem unless just a temporary bandaid while working on something more important.
+Always think of the minimum viable solution to a problem or change to make. make sure that works and then build on top of it. break things down into small testable pieces first. That said 
+
+**NO CHEATING!** I.e. don't comment out or skip a test to solve a problem unless its just a temporary bandaid while working on something more important.
 
 # keep all code implementations as consise as possible.
 
 Everything it needs nothing it doesn't. Every new line of code is one that potentially doesn't work 😄
 
-# Please check the documentation if you are implementing something potentially complex or nonstandard.
 
-often there are things we've learned already i.e. 
+# Check documentation if implementing something potentially complex or nonstandard.
 
-docs/dev_completed/constructor-mocking-android.md
+See `docs/README.md` for the full documentation index. often there are things we've learned already i.e. 
 
-documents how through a lot work an reserch we learned 
+**Key references:**
 
-mockKStatic, mockConstructor and anyConstructed ALMOST ALWAYS FAIL. And aren't worth trying anymore where there are better alternatives.
+- `docs/dev_completed/constructor-mocking-android.md` - **MockK limitations**: `mockkStatic`, `mockkConstructor`, and `anyConstructed` almost always fail in Android instrumentation tests. Use dependency injection patterns instead.
 
-also 
+- `docs/architecture/calendar_monitoring.md` - Deep detail on how calendar monitoring works (EVENT_REMINDER broadcasts, manual rescans, etc.)
 
-docs/calendar_monitoring.md
+- `docs/architecture/clock_implementation.md` - How `CNPlusClockInterface` enables testable time-dependent code
 
-goes into DEEP detail about how calendar monitoring works in the app
+
+# Copyright Headers
+
+For new or updated copyright headers, use:
+
+```
+Copyright (C) 2025 William Harris (wharris+cnplus@upscalews.com)
+```
+
+(William inherited the application from Sergey Parshin in 2020)
+
+# Never Catch the broad Exception class
+
+no catching Exception e. it can lead to hiding important bugs to catch. always do something more specific
+
+# Never use System.currentTimeMillis() directly
+
+Use `CNPlusClockInterface` instead - it enables testable time-dependent code.
+
+**Production code:** Inject `CNPlusSystemClock()` or access via interface property
+**Test code:** Use `TestTimeConstants.STANDARD_TEST_TIME` or `CNPlusTestClock`
+
+See `docs/architecture/clock_implementation.md` and `docs/dev_todo/system_current_time_millis_removal.md` for details.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on runtime behavior; primary risk is minor confusion if the new guidance/query is incorrect.
> 
> **Overview**
> Adds a new Cursor skill doc (`.cursor/skills/github-pr-comments/SKILL.md`) that provides a `gh api graphql` query for retrieving PR review threads with line numbers and resolved/outdated status.
> 
> Updates `.github/copilot-instructions.md` to formalize guidance on when code changes are allowed without confirmation, emphasize tests-first for larger changes, and add documentation pointers plus guardrails (avoid broad `Exception` catches and direct `System.currentTimeMillis()` usage; include updated copyright header format).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0335d2cbfab23f61a4e3e3bb5e09a837c60d64e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->